### PR TITLE
multi-bus support

### DIFF
--- a/common/daq/can_config.json
+++ b/common/daq/can_config.json
@@ -13,7 +13,7 @@
                             "signals":[
                                 {"sig_name": "test_sig", "type":"uint16_t", "length": 16}
                             ],
-                            "msg_period": 0,
+                            "msg_period": 15,
                             "msg_hlp": 5,
                             "msg_pgn": 1
                         },
@@ -22,7 +22,7 @@
                             "signals":[
                                 {"sig_name": "test_sig2", "type":"uint16_t", "length": 16}
                             ],
-                            "msg_period": 0,
+                            "msg_period": 15,
                             "msg_hlp": 5,
                             "msg_pgn": 2 
                         },
@@ -31,7 +31,7 @@
                             "signals":[
                                 {"sig_name": "test_sig3", "type":"uint16_t", "length": 16}
                             ],
-                            "msg_period": 0,
+                            "msg_period": 15,
                             "msg_hlp": 5,
                             "msg_pgn": 3
                         },
@@ -40,7 +40,7 @@
                             "signals":[
                                 {"sig_name": "test_sig4", "type":"uint16_t", "length": 16}
                             ],
-                            "msg_period": 0,
+                            "msg_period": 15,
                             "msg_hlp": 5,
                             "msg_pgn": 4 
                         },
@@ -49,7 +49,7 @@
                             "signals":[
                                 {"sig_name": "test_sig5", "type":"uint16_t", "length": 16}
                             ],
-                            "msg_period": 0,
+                            "msg_period": 15,
                             "msg_hlp": 5,
                             "msg_pgn": 5 
                         }
@@ -174,6 +174,49 @@
                     "rx":[ 
                         {"msg_name": "bitstream_flash_status"}
                     ]
+                },
+                {
+                    "node_name": "Precharge",
+                    "can_peripheral": "CAN1",
+                    "node_ssa": 58,
+                    "tx": [
+                        {
+                            "msg_name": "test_precharge_msg",
+                            "msg_desc": "test precharge desc",
+                            "signals": [
+                                {"sig_name": "test_precharge_sig", "type":"uint8_t", "length": 8}
+                            ],
+                            "msg_period": 15,
+                            "msg_hlp": 2,
+                            "msg_pgn": 512
+                        }
+                    ],
+                    "rx": [
+                        {"msg_name": "test_msg"}
+                    ]
+                }
+            ]
+        },
+        {
+            "bus_name": "Battery",
+            "nodes": [
+                {
+                    "node_name": "Precharge",
+                    "can_peripheral": "CAN2",
+                    "node_ssa": 42,
+                    "tx": [
+                        {
+                            "msg_name": "test_bat_msg",
+                            "msg_desc": "test_bat_desc",
+                            "signals": [
+                                {"sig_name": "test_bat_sig", "type": "uint8_t", "length": 8}
+                            ],
+                            "msg_period": 15,
+                            "msg_hlp": 1,
+                            "msg_pgn": 500
+                        }
+                    ],
+                    "rx": []
                 }
             ]
         }

--- a/common/daq/can_schema.json
+++ b/common/daq/can_schema.json
@@ -32,6 +32,10 @@
                     "type":"string",
                     "description":"name of the node (MCU)"
                 },
+                "can_peripheral":{
+                    "type":"string",
+                    "enum": ["CAN1", "CAN2"]
+                },
                 "node_ssa":{
                     "type":"integer",
                     "description":"subsystem address, lower = higher priority, 0-63",

--- a/common/daq/per_dbc.dbc
+++ b/common/daq/per_dbc.dbc
@@ -33,7 +33,7 @@ NS_ :
 
 BS_:
 
-BU_: TEST_NODE Pedalbox HUB_FL TORQUE_VECTOR TESTER DAQ
+BU_: TEST_NODE Pedalbox HUB_FL TORQUE_VECTOR TESTER Precharge DAQ Precharge
 
 
 BO_ 2483028044 test_msg: 2 TEST_NODE
@@ -91,8 +91,14 @@ BO_ 2415925631 bitstream_request: 5 TESTER
  SG_ download_size : 1|32@1+ (1,0) [0|0] "" Vector__XXX
  SG_ download_request : 0|1@1+ (1,0) [0|0] "" Vector__XXX
 
+BO_ 2281734202 test_precharge_msg: 1 Precharge
+ SG_ test_precharge_sig : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
 BO_ 2483028786 daq_command_TEST_NODE: 8 DAQ
  SG_ daq_command : 0|64@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2214624554 test_bat_msg: 1 Precharge
+ SG_ test_bat_sig : 0|8@1+ (1,0) [0|0] "" Vector__XXX
 
 
 
@@ -102,7 +108,9 @@ CM_ BU_ Pedalbox "";
 CM_ BU_ HUB_FL "";
 CM_ BU_ TORQUE_VECTOR "";
 CM_ BU_ TESTER "";
+CM_ BU_ Precharge "";
 CM_ BU_ DAQ "";
+CM_ BU_ Precharge "";
 CM_ BO_ 2483028044 "test_msg desc";
 CM_ SG_ 2483028044 test_sig "";
 CM_ BO_ 2483028108 "test_msg2 desc";
@@ -145,8 +153,12 @@ CM_ SG_ 2415925567 d0 "";
 CM_ BO_ 2415925631 "Bitstream state command";
 CM_ SG_ 2415925631 download_size "";
 CM_ SG_ 2415925631 download_request "";
+CM_ BO_ 2281734202 "test precharge desc";
+CM_ SG_ 2281734202 test_precharge_sig "";
 CM_ BO_ 2483028786 "daq command for node TEST_NODE";
 CM_ SG_ 2483028786 daq_command "";
+CM_ BO_ 2214624554 "test_bat_desc";
+CM_ SG_ 2214624554 test_bat_sig "";
 
 
 

--- a/common/daq/templates/can_parse_template.c
+++ b/common/daq/templates/can_parse_template.c
@@ -34,13 +34,8 @@ void canRxUpdate()
     if(qReceive(q_rx_can_a, &msg_header) == SUCCESS_G)
     {
         msg_data_a = (CanParsedData_t *) &msg_header.Data;
-        switch(msg_header.ExtId)
-        {
-            /* BEGIN AUTO CASES */
-            /* END AUTO CASES */
-            default:            // ID wasn't recognized
-                __asm__("nop"); // Do nothing so we can place a breakpoint
-        }
+        /* BEGIN AUTO CASES */
+        /* END AUTO CASES */
     }
 
     /* BEGIN AUTO STALE CHECKS */
@@ -72,6 +67,7 @@ bool initCANFilter()
 
     return timeout != PHAL_CAN_INIT_TIMEOUT;
 }
+
 
 void canProcessRxIRQs(CanMsgTypeDef_t* rx)
 {

--- a/common/daq/templates/can_parse_template.h
+++ b/common/daq/templates/can_parse_template.h
@@ -27,6 +27,10 @@
 /* BEGIN AUTO DLC DEFS */
 /* END AUTO DLC DEFS */
 
+// Message sending macros
+/* BEGIN AUTO SEND MACROS */
+/* END AUTO SEND MACROS */
+
 // Stale Checking
 #define STALE_THRESH 3 / 2 // 3 / 2 would be 150% of period
 /* BEGIN AUTO UP DEFS (Update Period)*/

--- a/common/daq/templates/daq_template.c
+++ b/common/daq/templates/daq_template.c
@@ -63,8 +63,11 @@ void sendDaqFrame(daq_tx_frame_writer_t tx_frame);
 void daqeQueuePop();
 void daqeQueuePush();
 
-bool daqInit()
+q_handle_t* q_tx_can_a;
+
+bool daqInit(q_handle_t* tx_a)
 {
+    q_tx_can_a = tx_a;
     // check all variables have been linked
     for(uint8_t i = 0; i < NUM_VARS; i++)
     {
@@ -439,9 +442,9 @@ void flushDaqFrame(daq_tx_frame_writer_t* tx_msg)
 // send tx frame
 void sendDaqFrame(daq_tx_frame_writer_t tx_frame)
 {
-    CanMsgTypeDef_t msg = {.IDE=1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
+    CanMsgTypeDef_t msg = {.Bus=CAN1, .IDE=1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
     memcpy(msg.Data, tx_frame.data, msg.DLC);
-    PHAL_txCANMessage(&msg);
+    qSendToBack(q_tx_can_a, &msg);
 }
 
 // call after read op

--- a/common/daq/templates/daq_template.h
+++ b/common/daq/templates/daq_template.h
@@ -20,14 +20,14 @@ typedef void (*read_func_ptr_t)(void* arg);
 typedef void (*write_func_ptr_t)(void* arg);
 
 // Make this match the node name within the daq_config.json
-#define NODE_NAME ""
+#define NODE_NAME "TEMPLATE_NODE"
 
 // BEGIN AUTO VAR COUNT
 // END AUTO VAR COUNT
 
 #define DAQ_UPDATE_PERIOD 15 // ms
 
-#define EEPROM_ENABLED 1
+#define EEPROM_ENABLED 0
 #define EEPROM_SIZE    4000 // bytes
 #define EEPROM_ADDR    0x50
 #define DAQ_SAVE_QUEUE_SIZE 8
@@ -96,9 +96,11 @@ extern daq_variable_t tracked_vars[NUM_VARS];
  *        If the eeprom is enabled, configures the eeprom to contain
  *        the variables and loads default values if applicable
  * 
+ * @param tx_a Address of the tx CAN buffer to send responses to
+ * 
  * @return Returns false if the operation was successful
  */
-bool daqInit();
+bool daqInit(q_handle_t* tx_a);
 
 /**
  * @brief Call periodically at DAQ_UPDATE_PERIOD

--- a/common/phal_L4/can/can.c
+++ b/common/phal_L4/can/can.c
@@ -10,66 +10,85 @@
  */
 #include "common/phal_L4/can/can.h"
 
-bool PHAL_initCAN(bool test_mode)
+bool PHAL_initCAN(CAN_TypeDef* bus, bool test_mode)
 {
     uint32_t timeout = 0;
 
     // Enable CAN Clock 
-    RCC->APB1ENR1 |= RCC_APB1ENR1_CAN1EN;
+    if (bus == CAN1)
+    {
+        RCC->APB1ENR1 |= RCC_APB1ENR1_CAN1EN;
+    }
+    #ifdef STM32L45
+    if (bus == CAN2)
+    {
+        RCC->APB1ENR1 |= RCC_APB1ENR1_CAN2EN;
+    } 
+    #endif
+
     asm("nop"); // Ensure that clock is enabled
 
     // Leave SLEEP state
-    CAN1->MCR &= ~CAN_MCR_SLEEP; 
-    while((CAN1->MSR & CAN_MSR_SLAK) && ++timeout < PHAL_CAN_INIT_TIMEOUT)
+    bus->MCR &= ~CAN_MCR_SLEEP; 
+    while((bus->MSR & CAN_MSR_SLAK) && ++timeout < PHAL_CAN_INIT_TIMEOUT)
         ;
     if (timeout == PHAL_CAN_INIT_TIMEOUT)
         return false;
     timeout = 0;
 
     // Enter INIT state
-    CAN1->MCR |= CAN_MCR_INRQ;
-    while(!(CAN1->MSR & CAN_MSR_INAK) && ++timeout < PHAL_CAN_INIT_TIMEOUT)
+    bus->MCR |= CAN_MCR_INRQ;
+    while(!(bus->MSR & CAN_MSR_INAK) && ++timeout < PHAL_CAN_INIT_TIMEOUT)
         ;
     if (timeout == PHAL_CAN_INIT_TIMEOUT)
         return false;
     timeout = 0;
 
     // Bit timing recovered from http://www.bittiming.can-wiki.info/
-    CAN1->BTR = 0x00050000;
+    bus->BTR = 0x00050000;
     
     // Keep the bus active
-    CAN1->MCR |= CAN_MCR_ABOM;
+    bus->MCR |= CAN_MCR_ABOM;
 
     // Loopback mode in testing mode
     if (test_mode)
     {
-        CAN1->BTR |= CAN_BTR_LBKM;
+        bus->BTR |= CAN_BTR_LBKM;
     }
     
     // Setup filters for all IDs
-    CAN1->FMR  |= CAN_FMR_FINIT;              // Enter init mode for filter banks
-    CAN1->FM1R &= ~(CAN_FM1R_FBM0_Msk);       // Set bank 0 to mask mode
-    CAN1->FS1R &= ~(1 << CAN_FS1R_FSC0_Pos);  // Set bank 0 to 16bit mode
-    CAN1->FA1R |= (1 << CAN_FA1R_FACT0_Pos);  // Activate bank 0
-    CAN1->sFilterRegister[0].FR1 = 0;         // Set mask to 0
-    CAN1->sFilterRegister[0].FR2 = 0;
-    CAN1->FMR  &= ~CAN_FMR_FINIT;             // Enable Filters
+    bus->FMR  |= CAN_FMR_FINIT;              // Enter init mode for filter banks
+    bus->FM1R &= ~(CAN_FM1R_FBM0_Msk);       // Set bank 0 to mask mode
+    bus->FS1R &= ~(1 << CAN_FS1R_FSC0_Pos);  // Set bank 0 to 16bit mode
+    bus->FA1R |= (1 << CAN_FA1R_FACT0_Pos);  // Activate bank 0
+    bus->sFilterRegister[0].FR1 = 0;         // Set mask to 0
+    bus->sFilterRegister[0].FR2 = 0;
+    bus->FMR  &= ~CAN_FMR_FINIT;             // Enable Filters
 
     // Enable FIFO0/1 RX message pending interrupt
-    CAN1->IER |= CAN_IER_FMPIE0;
-    CAN1->IER |= CAN_IER_FMPIE1;
+    bus->IER |= CAN_IER_FMPIE0;
+    bus->IER |= CAN_IER_FMPIE1;
 
     // Enter NORMAL mode
-    CAN1->MCR &= ~CAN_MCR_INRQ;
-    while((CAN1->MSR & CAN_MSR_INAK) && ++timeout < PHAL_CAN_INIT_TIMEOUT)
+    bus->MCR &= ~CAN_MCR_INRQ;
+    while((bus->MSR & CAN_MSR_INAK) && ++timeout < PHAL_CAN_INIT_TIMEOUT)
         ;
 
     return timeout != PHAL_CAN_INIT_TIMEOUT;
 }
 
-bool PHAL_deinitCAN()
+bool PHAL_deinitCAN(CAN_TypeDef* bus)
 {
-    RCC->APB1RSTR1 |= RCC_APB1RSTR1_CAN1RST;
+    if (bus == CAN1)
+    {
+        RCC->APB1RSTR1 |= RCC_APB1RSTR1_CAN1RST;
+    }
+    #ifdef STM32L45
+    else if(bus == CAN2)
+    {
+        RCC->APB1RSTR1 |= RCC_APB1RSTR1_CAN2RST;
+    }
+    #endif
     return true;
 }
 
@@ -79,17 +98,17 @@ bool PHAL_txCANMessage(CanMsgTypeDef_t* msg)
     uint32_t timeout = 0;
     uint32_t txOkay = 0;
 
-    if (CAN1->TSR & CAN_TSR_TME0)
+    if (msg->Bus->TSR & CAN_TSR_TME0)
     {
         txMbox = 0;
         txOkay = CAN_TSR_TXOK0;
     }
-    else if (CAN1->TSR & CAN_TSR_TME1)
+    else if (msg->Bus->TSR & CAN_TSR_TME1)
     {
         txMbox = 1;
         txOkay = CAN_TSR_TXOK1;
     }
-    else if (CAN1->TSR & CAN_TSR_TME2)
+    else if (msg->Bus->TSR & CAN_TSR_TME2)
     {
         txMbox = 2;
         txOkay = CAN_TSR_TXOK2;
@@ -99,25 +118,25 @@ bool PHAL_txCANMessage(CanMsgTypeDef_t* msg)
 
     if (msg->IDE == 0)
     {
-        CAN1->sTxMailBox[txMbox].TIR  = (msg->StdId << CAN_TI0R_STID_Pos);  // Standard ID
+        msg->Bus->sTxMailBox[txMbox].TIR  = (msg->StdId << CAN_TI0R_STID_Pos);  // Standard ID
     }
     else
     {
-        CAN1->sTxMailBox[txMbox].TIR  = (msg->ExtId << CAN_TI0R_EXID_Pos) | 4;  // Extended ID
+        msg->Bus->sTxMailBox[txMbox].TIR  = (msg->ExtId << CAN_TI0R_EXID_Pos) | 4;  // Extended ID
     }
-    CAN1->sTxMailBox[txMbox].TDTR = (msg->DLC << CAN_TDT0R_DLC_Pos);    // Data Length
-    CAN1->sTxMailBox[txMbox].TDLR = ((uint32_t) msg->Data[3] << 24) |
-                                    ((uint32_t) msg->Data[2] << 16) |
-                                    ((uint32_t) msg->Data[1] << 8)  |
-                                    ((uint32_t) msg->Data[0]);
-    CAN1->sTxMailBox[txMbox].TDHR = ((uint32_t) msg->Data[7] << 24) |
-                                    ((uint32_t) msg->Data[6] << 16) |
-                                    ((uint32_t) msg->Data[5] << 8)  |
-                                    ((uint32_t) msg->Data[4]);
+    msg->Bus->sTxMailBox[txMbox].TDTR = (msg->DLC << CAN_TDT0R_DLC_Pos);    // Data Length
+    msg->Bus->sTxMailBox[txMbox].TDLR = ((uint32_t) msg->Data[3] << 24) |
+                                        ((uint32_t) msg->Data[2] << 16) |
+                                        ((uint32_t) msg->Data[1] << 8)  |
+                                        ((uint32_t) msg->Data[0]);
+    msg->Bus->sTxMailBox[txMbox].TDHR = ((uint32_t) msg->Data[7] << 24) |
+                                        ((uint32_t) msg->Data[6] << 16) |
+                                        ((uint32_t) msg->Data[5] << 8)  |
+                                        ((uint32_t) msg->Data[4]);
     
-    CAN1->sTxMailBox[txMbox].TIR |= (0b1 << CAN_TI0R_TXRQ_Pos);         // Request TX
+    msg->Bus->sTxMailBox[txMbox].TIR |= (0b1 << CAN_TI0R_TXRQ_Pos);         // Request TX
 
-    while(!(CAN1->TSR & txOkay) && ++timeout < PHAL_CAN_TX_TIMEOUT)      // Wait for message to be sent within specified timeout
+    while(!(msg->Bus->TSR & txOkay) && ++timeout < PHAL_CAN_TX_TIMEOUT)      // Wait for message to be sent within specified timeout
         ;
 
     return timeout != PHAL_CAN_TX_TIMEOUT;
@@ -132,3 +151,15 @@ void  __attribute__((weak)) CAN1_RX1_IRQHandler()
 {
     // Implement for RX Mailbox 1 Handler
 }
+
+#ifdef STM32L45
+void  __attribute__((weak)) CAN2_RX0_IRQHandler()
+{
+    // Implement for RX Mailbox 0 Handler
+}
+
+void  __attribute__((weak)) CAN2_RX1_IRQHandler()
+{
+    // Implement for RX Mailbox 1 Handler
+}
+#endif

--- a/common/phal_L4/can/can.h
+++ b/common/phal_L4/can/can.h
@@ -12,7 +12,11 @@
 #ifndef _PHAL_CAN_H
 #define _PHAL_CAN_H
 
+#ifdef STM32L45
+#include "stm32l451xx.h"
+#else
 #include "stm32l432xx.h"
+#endif
 #include <stdbool.h>
 
 #define PHAL_CAN_TX_TIMEOUT   (1000U)
@@ -20,6 +24,7 @@
 
 typedef struct
 {
+  CAN_TypeDef* Bus; /*!< Specifies the bus. */
   uint16_t StdId; /*!< Specifies the standard identifier. */
   uint32_t ExtId; /*!< Specifies the extended identifier. */
   uint32_t IDE; /*!< Specifies the type of identifier for the message that will be transmitted.  */
@@ -35,9 +40,9 @@ typedef struct
  * @return true Peripheral sucessfully initalized
  * @return false Peripheral stalled during initilization
  */
-bool PHAL_initCAN(bool test_mode);
+bool PHAL_initCAN(CAN_TypeDef* bus, bool test_mode);
 
-bool PHAL_deinitCAN();
+bool PHAL_deinitCAN(CAN_TypeDef* bus);
 
 /**
  * @brief Find an empty TX mailbox and transmit a CAN message if one is found.

--- a/source/bootloader_l4/main.c
+++ b/source/bootloader_l4/main.c
@@ -5,7 +5,7 @@
 
 int main (void)
 {
-    PHAL_initCAN(false);
+    PHAL_initCAN(CAN1, false);
 
     return 0;
 }

--- a/source/l4_testing/can/can_parse.c
+++ b/source/l4_testing/can/can_parse.c
@@ -34,9 +34,9 @@ void canRxUpdate()
     if(qReceive(q_rx_can_a, &msg_header) == SUCCESS_G)
     {
         msg_data_a = (CanParsedData_t *) &msg_header.Data;
+        /* BEGIN AUTO CASES */
         switch(msg_header.ExtId)
         {
-            /* BEGIN AUTO CASES */
             case ID_THROTTLE_BRAKE:
                 can_data.throttle_brake.raw_throttle = msg_data_a->throttle_brake.raw_throttle;
                 can_data.throttle_brake.raw_brake = msg_data_a->throttle_brake.raw_brake;
@@ -60,10 +60,10 @@ void canRxUpdate()
                 can_data.daq_command_TEST_NODE.daq_command = msg_data_a->daq_command_TEST_NODE.daq_command;
                 daq_command_TEST_NODE_CALLBACK(&msg_header);
                 break;
-            /* END AUTO CASES */
-            default:            // ID wasn't recognized
-                __asm__("nop"); // Do nothing so we can place a breakpoint
+            default:
+                __asm__("nop");
         }
+        /* END AUTO CASES */
     }
 
     /* BEGIN AUTO STALE CHECKS */

--- a/source/l4_testing/can/can_parse.h
+++ b/source/l4_testing/can/can_parse.h
@@ -47,6 +47,46 @@
 #define DLC_DAQ_COMMAND_TEST_NODE 8
 /* END AUTO DLC DEFS */
 
+// Message sending macros
+/* BEGIN AUTO SEND MACROS */
+#define SEND_TEST_MSG(queue, test_sig_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG, .DLC=DLC_TEST_MSG, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->test_msg.test_sig = test_sig_;\
+        qSendToBack(&queue, &msg);\
+    } while(0)
+#define SEND_TEST_MSG2(queue, test_sig2_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG2, .DLC=DLC_TEST_MSG2, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->test_msg2.test_sig2 = test_sig2_;\
+        qSendToBack(&queue, &msg);\
+    } while(0)
+#define SEND_TEST_MSG3(queue, test_sig3_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG3, .DLC=DLC_TEST_MSG3, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->test_msg3.test_sig3 = test_sig3_;\
+        qSendToBack(&queue, &msg);\
+    } while(0)
+#define SEND_TEST_MSG4(queue, test_sig4_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG4, .DLC=DLC_TEST_MSG4, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->test_msg4.test_sig4 = test_sig4_;\
+        qSendToBack(&queue, &msg);\
+    } while(0)
+#define SEND_TEST_MSG5(queue, test_sig5_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG5, .DLC=DLC_TEST_MSG5, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->test_msg5.test_sig5 = test_sig5_;\
+        qSendToBack(&queue, &msg);\
+    } while(0)
+#define SEND_DAQ_RESPONSE_TEST_NODE(queue, daq_response_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=DLC_DAQ_RESPONSE_TEST_NODE, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->daq_response_TEST_NODE.daq_response = daq_response_;\
+        qSendToBack(&queue, &msg);\
+    } while(0)
+/* END AUTO SEND MACROS */
+
 // Stale Checking
 #define STALE_THRESH 3 / 2 // 3 / 2 would be 150% of period
 /* BEGIN AUTO UP DEFS (Update Period)*/
@@ -63,38 +103,38 @@
 typedef union { __attribute__((packed))
     struct {
         uint64_t test_sig: 16;
-    }test_msg;
+    } test_msg;
     struct {
         uint64_t test_sig2: 16;
-    }test_msg2;
+    } test_msg2;
     struct {
         uint64_t test_sig3: 16;
-    }test_msg3;
+    } test_msg3;
     struct {
         uint64_t test_sig4: 16;
-    }test_msg4;
+    } test_msg4;
     struct {
         uint64_t test_sig5: 16;
-    }test_msg5;
+    } test_msg5;
     struct {
         uint64_t daq_response: 64;
-    }daq_response_TEST_NODE;
+    } daq_response_TEST_NODE;
     struct {
         uint64_t raw_throttle: 16;
         uint64_t raw_brake: 16;
-    }throttle_brake;
+    } throttle_brake;
     struct {
         uint64_t fl_speed: 8;
         uint64_t fr_speed: 8;
         uint64_t bl_speed: 8;
         uint64_t br_speed: 8;
-    }wheel_speeds;
+    } wheel_speeds;
     struct {
         uint64_t current: 8;
-    }motor_current;
+    } motor_current;
     struct {
         uint64_t daq_command: 64;
-    }daq_command_TEST_NODE;
+    } daq_command_TEST_NODE;
     uint8_t raw_data[8];
 } CanParsedData_t;
 /* END AUTO MESSAGE STRUCTURE */

--- a/source/l4_testing/daq/daq.c
+++ b/source/l4_testing/daq/daq.c
@@ -70,8 +70,11 @@ void sendDaqFrame(daq_tx_frame_writer_t tx_frame);
 void daqeQueuePop();
 void daqeQueuePush();
 
-bool daqInit()
+q_handle_t* q_tx_can_a;
+
+bool daqInit(q_handle_t* tx_a)
 {
+    q_tx_can_a = tx_a;
     // check all variables have been linked
     for(uint8_t i = 0; i < NUM_VARS; i++)
     {
@@ -446,9 +449,9 @@ void flushDaqFrame(daq_tx_frame_writer_t* tx_msg)
 // send tx frame
 void sendDaqFrame(daq_tx_frame_writer_t tx_frame)
 {
-    CanMsgTypeDef_t msg = {.IDE=1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
+    CanMsgTypeDef_t msg = {.Bus=CAN1, .IDE=1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
     memcpy(msg.Data, tx_frame.data, msg.DLC);
-    PHAL_txCANMessage(&msg);
+    qSendToBack(q_tx_can_a, &msg);
 }
 
 // call after read op

--- a/source/l4_testing/daq/daq.h
+++ b/source/l4_testing/daq/daq.h
@@ -102,9 +102,11 @@ extern daq_variable_t tracked_vars[NUM_VARS];
  *        If the eeprom is enabled, configures the eeprom to contain
  *        the variables and loads default values if applicable
  * 
+ * @param tx_a Address of the tx CAN buffer to send responses to
+ * 
  * @return Returns false if the operation was successful
  */
-bool daqInit();
+bool daqInit(q_handle_t* tx_a);
 
 /**
  * @brief Call periodically at DAQ_UPDATE_PERIOD

--- a/source/main_module/main.c
+++ b/source/main_module/main.c
@@ -18,7 +18,7 @@ int main (void)
 {
     PHAL_initGPIO(gpio_config, sizeof(gpio_config)/sizeof(GPIOInitConfig_t));
 
-    PHAL_initCAN(true);
+    PHAL_initCAN(CAN1, true);
     NVIC_EnableIRQ(CAN1_RX0_IRQn);
 
     schedInit(SystemCoreClock);

--- a/source/precharge/can/can_parse.c
+++ b/source/precharge/can/can_parse.c
@@ -35,30 +35,34 @@ void canRxUpdate()
     {
         msg_data_a = (CanParsedData_t *) &msg_header.Data;
         /* BEGIN AUTO CASES */
-        switch(msg_header.ExtId)
+        if (msg_header->Bus == CAN1)
         {
-            case ID_BITSTREAM_DATA:
-                can_data.bitstream_data.d0 = msg_data_a->bitstream_data.d0;
-                can_data.bitstream_data.d1 = msg_data_a->bitstream_data.d1;
-                can_data.bitstream_data.d2 = msg_data_a->bitstream_data.d2;
-                can_data.bitstream_data.d3 = msg_data_a->bitstream_data.d3;
-                can_data.bitstream_data.d4 = msg_data_a->bitstream_data.d4;
-                can_data.bitstream_data.d5 = msg_data_a->bitstream_data.d5;
-                can_data.bitstream_data.d6 = msg_data_a->bitstream_data.d6;
-                can_data.bitstream_data.d7 = msg_data_a->bitstream_data.d7;
-                break;
-            case ID_BITSTREAM_REQUEST:
-                can_data.bitstream_request.download_request = msg_data_a->bitstream_request.download_request;
-                can_data.bitstream_request.download_size = msg_data_a->bitstream_request.download_size;
-                bitstream_request_CALLBACK(msg_data_a);
-                break;
-            default:
-                __asm__("nop");
+            switch(msg_header.ExtId)
+            {
+                default:
+                    __asm__("nop");
+            }
+        }
+        else if (msg_header->Bus == CAN1)
+        {
+            switch(msg_header.ExtId)
+            {
+                case ID_TEST_MSG:
+                    can_data.test_msg.test_sig = msg_data_a->test_msg.test_sig;
+                    can_data.test_msg.stale = 0;
+                    can_data.test_msg.last_rx = curr_tick;
+                    break;
+                default:
+                    __asm__("nop");
+            }
         }
         /* END AUTO CASES */
     }
 
     /* BEGIN AUTO STALE CHECKS */
+    CHECK_STALE(can_data.test_msg.stale,
+                curr_tick, can_data.test_msg.last_rx,
+                UP_TEST_MSG);
     /* END AUTO STALE CHECKS */
 }
 
@@ -77,8 +81,7 @@ bool initCANFilter()
 
     /* BEGIN AUTO FILTER */
     CAN1->FA1R |= (1 << 0);    // configure bank 0
-    CAN1->sFilterRegister[0].FR1 = (ID_BITSTREAM_DATA << 3) | 4;
-    CAN1->sFilterRegister[0].FR2 = (ID_BITSTREAM_REQUEST << 3) | 4;
+    CAN1->sFilterRegister[0].FR1 = (ID_TEST_MSG << 3) | 4;
     /* END AUTO FILTER */
 
     CAN1->FMR  &= ~CAN_FMR_FINIT;             // Enable Filters (exit filter init mode)
@@ -100,9 +103,6 @@ void canProcessRxIRQs(CanMsgTypeDef_t* rx)
     switch(rx->ExtId)
     {
         /* BEGIN AUTO RX IRQ */
-            case ID_BITSTREAM_DATA:
-                bitstream_data_IRQ(msg_data_a);
-                break;
         /* END AUTO RX IRQ */
         default:
             __asm__("nop");

--- a/source/torque_vector/main.c
+++ b/source/torque_vector/main.c
@@ -80,7 +80,7 @@ int main (void)
     if (1 != PHAL_initGPIO(gpio_config, sizeof(gpio_config)/sizeof(GPIOInitConfig_t)))
         PHAL_FaltHandler();
         
-    if (1 != PHAL_initCAN(false))
+    if (1 != PHAL_initCAN(CAN1, false))
         PHAL_FaltHandler();
 
     if (1 != PHAL_qspiInit())


### PR DESCRIPTION
For each junction node, define "can_peripheral" as CAN1 or CAN2. For filtering, the CAN2 filters are generated, but the surrounding filter setup code will have to be manually added for CAN2.