### PR TITLE
multi node testing (slight updates on daq system)

### DIFF
--- a/common/daq/can_config.json
+++ b/common/daq/can_config.json
@@ -206,7 +206,35 @@
                     "rx":[ 
                         {"msg_name": "bitstream_flash_status"}
                     ]
-                },
+                }
+            ]
+        },
+        {
+            "bus_name": "Battery",
+            "nodes": [
+                {
+                    "node_name": "Precharge",
+                    "can_peripheral": "CAN2",
+                    "node_ssa": 42,
+                    "tx": [
+                        {
+                            "msg_name": "test_bat_msg",
+                            "msg_desc": "test_bat_desc",
+                            "signals": [
+                                {"sig_name": "test_bat_sig", "type": "uint8_t", "length": 8}
+                            ],
+                            "msg_period": 15,
+                            "msg_hlp": 1,
+                            "msg_pgn": 500
+                        }
+                    ],
+                    "rx": []
+                }
+            ]
+        },
+        {
+            "bus_name": "Test",
+            "nodes": [
                 {
                     "node_name": "TEST_NODE",
                     "node_ssa":63,
@@ -258,31 +286,60 @@
                         }
                     ],
                     "rx":[
-                        {"msg_name":"raw_throttle_brake"}
                     ]
-                }
-            ]
-        },
-        {
-            "bus_name": "Battery",
-            "nodes": [
+                },
                 {
-                    "node_name": "Precharge",
-                    "can_peripheral": "CAN2",
-                    "node_ssa": 42,
-                    "tx": [
-                        {
-                            "msg_name": "test_bat_msg",
-                            "msg_desc": "test_bat_desc",
-                            "signals": [
-                                {"sig_name": "test_bat_sig", "type": "uint8_t", "length": 8}
+                    "node_name": "TEST_NODE_2",
+                    "node_ssa":61,
+                    "tx":[
+                        {   "msg_name":"test_msg_2",
+                            "msg_desc":"test_msg desc",
+                            "signals":[
+                                {"sig_name": "test_sig", "type":"uint16_t", "length": 16}
                             ],
                             "msg_period": 15,
-                            "msg_hlp": 1,
-                            "msg_pgn": 500
+                            "msg_hlp": 5,
+                            "msg_pgn": 1
+                        },
+                        {   "msg_name":"test_msg2_2",
+                            "msg_desc":"test_msg2 desc",
+                            "signals":[
+                                {"sig_name": "test_sig2", "type":"uint16_t", "length": 16}
+                            ],
+                            "msg_period": 15,
+                            "msg_hlp": 5,
+                            "msg_pgn": 2 
+                        },
+                        {   "msg_name":"test_msg3_2",
+                            "msg_desc":"test_msg2 desc",
+                            "signals":[
+                                {"sig_name": "test_sig3", "type":"uint16_t", "length": 16}
+                            ],
+                            "msg_period": 15,
+                            "msg_hlp": 5,
+                            "msg_pgn": 3
+                        },
+                        {   "msg_name":"test_msg4_2",
+                            "msg_desc":"test_msg4 desc",
+                            "signals":[
+                                {"sig_name": "test_sig4", "type":"uint16_t", "length": 16}
+                            ],
+                            "msg_period": 15,
+                            "msg_hlp": 5,
+                            "msg_pgn": 4 
+                        },
+                        {   "msg_name":"test_msg5_2",
+                            "msg_desc":"test_msg5 desc",
+                            "signals":[
+                                {"sig_name": "test_sig5", "type":"uint16_t", "length": 16}
+                            ],
+                            "msg_period": 15,
+                            "msg_hlp": 5,
+                            "msg_pgn": 5 
                         }
                     ],
-                    "rx": []
+                    "rx":[
+                    ]
                 }
             ]
         }

--- a/common/daq/daq_config.json
+++ b/common/daq/daq_config.json
@@ -2,7 +2,7 @@
     "$schema":"./daq_schema.json",
     "busses":[
         {
-            "bus_name":"Main",
+            "bus_name":"Test",
             "daq_ssa":50,
             "daq_rx_pgn":1048575,
             "nodes":[
@@ -18,6 +18,16 @@
                             "eeprom":{"label":"grn", "version":0}},
                         {"var_name":"blue_on", "read_only":false, "bit_length":1,
                             "eeprom":{"label":"blu", "version":0}}
+                    ]
+                },
+                {
+                    "node_name":"TEST_NODE_2",
+                    "variables":[
+                        {"var_name":"test_var", "read_only":true, "bit_length":8},
+                        {"var_name":"test_var2", "read_only":false, "bit_length":12},
+                        {"var_name":"red_on", "read_only":false, "bit_length":1},
+                        {"var_name":"green_on", "read_only":false, "bit_length":1},
+                        {"var_name":"blue_on", "read_only":false, "bit_length":1}
                     ]
                 }
             ]

--- a/common/daq/per_dbc.dbc
+++ b/common/daq/per_dbc.dbc
@@ -33,7 +33,7 @@ NS_ :
 
 BS_:
 
-BU_: Main_Module Torque_Vector Driveline Precharge Dashboard TESTER TEST_NODE DAQ Precharge
+BU_: Main_Module Torque_Vector Driveline Precharge Dashboard TESTER Precharge TEST_NODE TEST_NODE_2 DAQ
 
 
 BO_ 2214592576 driver_request: 4 Main_Module
@@ -101,6 +101,9 @@ BO_ 2415925630 bitstream_request: 5 TESTER
  SG_ download_size : 1|32@1+ (1,0) [0|0] "" Vector__XXX
  SG_ download_request : 0|1@1+ (1,0) [0|0] "" Vector__XXX
 
+BO_ 2214624554 test_bat_msg: 1 Precharge
+ SG_ test_bat_sig : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
 BO_ 2483028095 test_msg: 2 TEST_NODE
  SG_ test_sig : 0|16@1+ (1,0) [0|0] "" Vector__XXX
 
@@ -119,11 +122,29 @@ BO_ 2483028351 test_msg5: 2 TEST_NODE
 BO_ 2550136831 daq_response_TEST_NODE: 8 TEST_NODE
  SG_ daq_response : 0|64@1+ (1,0) [0|0] "" Vector__XXX
 
+BO_ 2483028093 test_msg_2: 2 TEST_NODE_2
+ SG_ test_sig : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2483028157 test_msg2_2: 2 TEST_NODE_2
+ SG_ test_sig2 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2483028221 test_msg3_2: 2 TEST_NODE_2
+ SG_ test_sig3 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2483028285 test_msg4_2: 2 TEST_NODE_2
+ SG_ test_sig4 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2483028349 test_msg5_2: 2 TEST_NODE_2
+ SG_ test_sig5 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2550136829 daq_response_TEST_NODE_2: 8 TEST_NODE_2
+ SG_ daq_response : 0|64@1+ (1,0) [0|0] "" Vector__XXX
+
 BO_ 2483032050 daq_command_TEST_NODE: 8 DAQ
  SG_ daq_command : 0|64@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 2214624554 test_bat_msg: 1 Precharge
- SG_ test_bat_sig : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+BO_ 2483031922 daq_command_TEST_NODE_2: 8 DAQ
+ SG_ daq_command : 0|64@1+ (1,0) [0|0] "" Vector__XXX
 
 
 
@@ -134,9 +155,10 @@ CM_ BU_ Driveline "";
 CM_ BU_ Precharge "";
 CM_ BU_ Dashboard "";
 CM_ BU_ TESTER "";
-CM_ BU_ TEST_NODE "";
-CM_ BU_ DAQ "";
 CM_ BU_ Precharge "";
+CM_ BU_ TEST_NODE "";
+CM_ BU_ TEST_NODE_2 "";
+CM_ BU_ DAQ "";
 CM_ BO_ 2214592576 "Driver throttle/regeneration request";
 CM_ SG_ 2214592576 regen "";
 CM_ SG_ 2214592576 accel "";
@@ -189,6 +211,8 @@ CM_ SG_ 2415925566 d0 "";
 CM_ BO_ 2415925630 "Bitstream state command";
 CM_ SG_ 2415925630 download_size "";
 CM_ SG_ 2415925630 download_request "";
+CM_ BO_ 2214624554 "test_bat_desc";
+CM_ SG_ 2214624554 test_bat_sig "";
 CM_ BO_ 2483028095 "test_msg desc";
 CM_ SG_ 2483028095 test_sig "";
 CM_ BO_ 2483028159 "test_msg2 desc";
@@ -201,10 +225,22 @@ CM_ BO_ 2483028351 "test_msg5 desc";
 CM_ SG_ 2483028351 test_sig5 "";
 CM_ BO_ 2550136831 "daq response from node TEST_NODE";
 CM_ SG_ 2550136831 daq_response "";
+CM_ BO_ 2483028093 "test_msg desc";
+CM_ SG_ 2483028093 test_sig "";
+CM_ BO_ 2483028157 "test_msg2 desc";
+CM_ SG_ 2483028157 test_sig2 "";
+CM_ BO_ 2483028221 "test_msg2 desc";
+CM_ SG_ 2483028221 test_sig3 "";
+CM_ BO_ 2483028285 "test_msg4 desc";
+CM_ SG_ 2483028285 test_sig4 "";
+CM_ BO_ 2483028349 "test_msg5 desc";
+CM_ SG_ 2483028349 test_sig5 "";
+CM_ BO_ 2550136829 "daq response from node TEST_NODE_2";
+CM_ SG_ 2550136829 daq_response "";
 CM_ BO_ 2483032050 "daq command for node TEST_NODE";
 CM_ SG_ 2483032050 daq_command "";
-CM_ BO_ 2214624554 "test_bat_desc";
-CM_ SG_ 2214624554 test_bat_sig "";
+CM_ BO_ 2483031922 "daq command for node TEST_NODE_2";
+CM_ SG_ 2483031922 daq_command "";
 
 
 

--- a/common/daq/templates/daq_template.c
+++ b/common/daq/templates/daq_template.c
@@ -48,6 +48,8 @@ typedef struct
 daq_eeprom_status_t daq_e_stat = {.read_idx=0, .write_idx=0, .data_buff_lock=0, .queue_current=0};
 
 // BEGIN AUTO VAR DEFS
+daq_variable_t tracked_vars[NUM_VARS] = {
+};
 // END AUTO VAR DEFS
 
 // function prototypes
@@ -293,7 +295,9 @@ bool pubVarStop(uint8_t var_id)
  * write is followed by variable data, length pre-specified for each var id
  * publish is followed by publish rate (in Hz)
  */
+// BEGIN AUTO CALLBACK DEF
 void daq_command_TEST_NODE_CALLBACK(CanMsgTypeDef_t* msg_header_a)
+// END AUTO CALLBACK DEF
 {
 
     daq_tx_frame_writer_t tx_writer = {.data={0}, .curr_bit=0};
@@ -442,7 +446,12 @@ void flushDaqFrame(daq_tx_frame_writer_t* tx_msg)
 // send tx frame
 void sendDaqFrame(daq_tx_frame_writer_t tx_frame)
 {
-    CanMsgTypeDef_t msg = {.Bus=CAN1, .IDE=1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
+    CanMsgTypeDef_t msg = {.IDE=1, 
+    // BEGIN AUTO DAQ SEND DEF
+                           .Bus=CAN1,
+                           .ExtId=ID_DAQ_RESPONSE_TEST_NODE,
+    // END AUTO DAQ SEND DEF
+                           .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
     memcpy(msg.Data, tx_frame.data, msg.DLC);
     qSendToBack(q_tx_can_a, &msg);
 }

--- a/common/daq/templates/daq_template.h
+++ b/common/daq/templates/daq_template.h
@@ -13,8 +13,8 @@
 
 #include <string.h>
 #include "common/phal_L4/can/can.h"
-#include "common/eeprom/eeprom.h"
 #include "can_parse.h"
+#include "common/eeprom/eeprom.h"
 
 typedef void (*read_func_ptr_t)(void* arg);
 typedef void (*write_func_ptr_t)(void* arg);
@@ -23,11 +23,13 @@ typedef void (*write_func_ptr_t)(void* arg);
 #define NODE_NAME "TEMPLATE_NODE"
 
 // BEGIN AUTO VAR COUNT
+#define NUM_VARS 0
 // END AUTO VAR COUNT
 
 #define DAQ_UPDATE_PERIOD 15 // ms
 
 #define EEPROM_ENABLED 0
+
 #define EEPROM_SIZE    4000 // bytes
 #define EEPROM_ADDR    0x50
 #define DAQ_SAVE_QUEUE_SIZE 8

--- a/source/l4_testing/can/can_parse.c
+++ b/source/l4_testing/can/can_parse.c
@@ -37,17 +37,9 @@ void canRxUpdate()
         /* BEGIN AUTO CASES */
         switch(msg_header.ExtId)
         {
-            case ID_RAW_THROTTLE_BRAKE:
-                can_data.raw_throttle_brake.throttle0 = msg_data_a->raw_throttle_brake.throttle0;
-                can_data.raw_throttle_brake.throttle1 = msg_data_a->raw_throttle_brake.throttle1;
-                can_data.raw_throttle_brake.brake0 = msg_data_a->raw_throttle_brake.brake0;
-                can_data.raw_throttle_brake.brake1 = msg_data_a->raw_throttle_brake.brake1;
-                can_data.raw_throttle_brake.stale = 0;
-                can_data.raw_throttle_brake.last_rx = curr_tick;
-                break;
-            case ID_DAQ_COMMAND_TEST_NODE:
-                can_data.daq_command_TEST_NODE.daq_command = msg_data_a->daq_command_TEST_NODE.daq_command;
-                daq_command_TEST_NODE_CALLBACK(&msg_header);
+            case ID_DAQ_COMMAND_TEST_NODE_2:
+                can_data.daq_command_TEST_NODE_2.daq_command = msg_data_a->daq_command_TEST_NODE_2.daq_command;
+                daq_command_TEST_NODE_2_CALLBACK(&msg_header);
                 break;
             default:
                 __asm__("nop");
@@ -56,9 +48,6 @@ void canRxUpdate()
     }
 
     /* BEGIN AUTO STALE CHECKS */
-    CHECK_STALE(can_data.raw_throttle_brake.stale,
-                curr_tick, can_data.raw_throttle_brake.last_rx,
-                UP_RAW_THROTTLE_BRAKE);
     /* END AUTO STALE CHECKS */
 }
 
@@ -77,8 +66,7 @@ bool initCANFilter()
 
     /* BEGIN AUTO FILTER */
     CAN1->FA1R |= (1 << 0);    // configure bank 0
-    CAN1->sFilterRegister[0].FR1 = (ID_RAW_THROTTLE_BRAKE << 3) | 4;
-    CAN1->sFilterRegister[0].FR2 = (ID_DAQ_COMMAND_TEST_NODE << 3) | 4;
+    CAN1->sFilterRegister[0].FR1 = (ID_DAQ_COMMAND_TEST_NODE_2 << 3) | 4;
     /* END AUTO FILTER */
 
     CAN1->FMR  &= ~CAN_FMR_FINIT;             // Enable Filters (exit filter init mode)

--- a/source/l4_testing/can/can_parse.h
+++ b/source/l4_testing/can/can_parse.h
@@ -15,70 +15,69 @@
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
-#define NODE_NAME "TEST_NODE"
+
+#define NODE_NAME "TEST_NODE_2"
 
 #define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
-#define ID_TEST_MSG 0x1400007f
-#define ID_TEST_MSG2 0x140000bf
-#define ID_TEST_MSG3 0x140000ff
-#define ID_TEST_MSG4 0x1400013f
-#define ID_TEST_MSG5 0x1400017f
-#define ID_DAQ_RESPONSE_TEST_NODE 0x17ffffff
-#define ID_RAW_THROTTLE_BRAKE 0x14000285
-#define ID_DAQ_COMMAND_TEST_NODE 0x14000ff2
+#define ID_TEST_MSG_2 0x1400007d
+#define ID_TEST_MSG2_2 0x140000bd
+#define ID_TEST_MSG3_2 0x140000fd
+#define ID_TEST_MSG4_2 0x1400013d
+#define ID_TEST_MSG5_2 0x1400017d
+#define ID_DAQ_RESPONSE_TEST_NODE_2 0x17fffffd
+#define ID_DAQ_COMMAND_TEST_NODE_2 0x14000f72
 /* END AUTO ID DEFS */
 
 // Message DLC definitions
 /* BEGIN AUTO DLC DEFS */
-#define DLC_TEST_MSG 2
-#define DLC_TEST_MSG2 2
-#define DLC_TEST_MSG3 2
-#define DLC_TEST_MSG4 2
-#define DLC_TEST_MSG5 2
-#define DLC_DAQ_RESPONSE_TEST_NODE 8
-#define DLC_RAW_THROTTLE_BRAKE 8
-#define DLC_DAQ_COMMAND_TEST_NODE 8
+#define DLC_TEST_MSG_2 2
+#define DLC_TEST_MSG2_2 2
+#define DLC_TEST_MSG3_2 2
+#define DLC_TEST_MSG4_2 2
+#define DLC_TEST_MSG5_2 2
+#define DLC_DAQ_RESPONSE_TEST_NODE_2 8
+#define DLC_DAQ_COMMAND_TEST_NODE_2 8
 /* END AUTO DLC DEFS */
 
 // Message sending macros
 /* BEGIN AUTO SEND MACROS */
-#define SEND_TEST_MSG(queue, test_sig_) do {\
-        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG, .DLC=DLC_TEST_MSG, .IDE=1};\
+#define SEND_TEST_MSG_2(queue, test_sig_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG_2, .DLC=DLC_TEST_MSG_2, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
-        data_a->test_msg.test_sig = test_sig_;\
+        data_a->test_msg_2.test_sig = test_sig_;\
         qSendToBack(&queue, &msg);\
     } while(0)
-#define SEND_TEST_MSG2(queue, test_sig2_) do {\
-        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG2, .DLC=DLC_TEST_MSG2, .IDE=1};\
+#define SEND_TEST_MSG2_2(queue, test_sig2_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG2_2, .DLC=DLC_TEST_MSG2_2, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
-        data_a->test_msg2.test_sig2 = test_sig2_;\
+        data_a->test_msg2_2.test_sig2 = test_sig2_;\
         qSendToBack(&queue, &msg);\
     } while(0)
-#define SEND_TEST_MSG3(queue, test_sig3_) do {\
-        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG3, .DLC=DLC_TEST_MSG3, .IDE=1};\
+#define SEND_TEST_MSG3_2(queue, test_sig3_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG3_2, .DLC=DLC_TEST_MSG3_2, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
-        data_a->test_msg3.test_sig3 = test_sig3_;\
+        data_a->test_msg3_2.test_sig3 = test_sig3_;\
         qSendToBack(&queue, &msg);\
     } while(0)
-#define SEND_TEST_MSG4(queue, test_sig4_) do {\
-        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG4, .DLC=DLC_TEST_MSG4, .IDE=1};\
+#define SEND_TEST_MSG4_2(queue, test_sig4_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG4_2, .DLC=DLC_TEST_MSG4_2, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
-        data_a->test_msg4.test_sig4 = test_sig4_;\
+        data_a->test_msg4_2.test_sig4 = test_sig4_;\
         qSendToBack(&queue, &msg);\
     } while(0)
-#define SEND_TEST_MSG5(queue, test_sig5_) do {\
-        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG5, .DLC=DLC_TEST_MSG5, .IDE=1};\
+#define SEND_TEST_MSG5_2(queue, test_sig5_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_TEST_MSG5_2, .DLC=DLC_TEST_MSG5_2, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
-        data_a->test_msg5.test_sig5 = test_sig5_;\
+        data_a->test_msg5_2.test_sig5 = test_sig5_;\
         qSendToBack(&queue, &msg);\
     } while(0)
-#define SEND_DAQ_RESPONSE_TEST_NODE(queue, daq_response_) do {\
-        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=DLC_DAQ_RESPONSE_TEST_NODE, .IDE=1};\
+#define SEND_DAQ_RESPONSE_TEST_NODE_2(queue, daq_response_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE_2, .DLC=DLC_DAQ_RESPONSE_TEST_NODE_2, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
-        data_a->daq_response_TEST_NODE.daq_response = daq_response_;\
+        data_a->daq_response_TEST_NODE_2.daq_response = daq_response_;\
         qSendToBack(&queue, &msg);\
     } while(0)
 /* END AUTO SEND MACROS */
@@ -86,7 +85,6 @@
 // Stale Checking
 #define STALE_THRESH 3 / 2 // 3 / 2 would be 150% of period
 /* BEGIN AUTO UP DEFS (Update Period)*/
-#define UP_RAW_THROTTLE_BRAKE 5
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
@@ -97,31 +95,25 @@
 typedef union { __attribute__((packed))
     struct {
         uint64_t test_sig: 16;
-    } test_msg;
+    } test_msg_2;
     struct {
         uint64_t test_sig2: 16;
-    } test_msg2;
+    } test_msg2_2;
     struct {
         uint64_t test_sig3: 16;
-    } test_msg3;
+    } test_msg3_2;
     struct {
         uint64_t test_sig4: 16;
-    } test_msg4;
+    } test_msg4_2;
     struct {
         uint64_t test_sig5: 16;
-    } test_msg5;
+    } test_msg5_2;
     struct {
         uint64_t daq_response: 64;
-    } daq_response_TEST_NODE;
-    struct {
-        uint64_t throttle0: 16;
-        uint64_t throttle1: 16;
-        uint64_t brake0: 16;
-        uint64_t brake1: 16;
-    } raw_throttle_brake;
+    } daq_response_TEST_NODE_2;
     struct {
         uint64_t daq_command: 64;
-    } daq_command_TEST_NODE;
+    } daq_command_TEST_NODE_2;
     uint8_t raw_data[8];
 } CanParsedData_t;
 /* END AUTO MESSAGE STRUCTURE */
@@ -131,23 +123,15 @@ typedef union { __attribute__((packed))
 /* BEGIN AUTO CAN DATA STRUCTURE */
 typedef struct {
     struct {
-        uint16_t throttle0;
-        uint16_t throttle1;
-        uint16_t brake0;
-        uint16_t brake1;
-        uint8_t stale;
-        uint32_t last_rx;
-    } raw_throttle_brake;
-    struct {
         uint64_t daq_command;
-    } daq_command_TEST_NODE;
+    } daq_command_TEST_NODE_2;
 } can_data_t;
 /* END AUTO CAN DATA STRUCTURE */
 
 extern can_data_t can_data;
 
 /* BEGIN AUTO EXTERN CALLBACK */
-extern void daq_command_TEST_NODE_CALLBACK(CanMsgTypeDef_t* msg_header_a);
+extern void daq_command_TEST_NODE_2_CALLBACK(CanMsgTypeDef_t* msg_header_a);
 /* END AUTO EXTERN CALLBACK */
 
 /* BEGIN AUTO EXTERN RX IRQ */

--- a/source/l4_testing/daq/daq.c
+++ b/source/l4_testing/daq/daq.c
@@ -50,10 +50,10 @@ daq_eeprom_status_t daq_e_stat = {.read_idx=0, .write_idx=0, .data_buff_lock=0, 
 // BEGIN AUTO VAR DEFS
 daq_variable_t tracked_vars[NUM_VARS] = {
     {.is_read_only=1, .bit_length=8, .eeprom_enabled=0},
-    {.is_read_only=0, .bit_length=12, .eeprom_enabled=1, .eeprom_label="tv2", .eeprom_version=0},
-    {.is_read_only=0, .bit_length=1, .eeprom_enabled=1, .eeprom_label="red", .eeprom_version=0},
-    {.is_read_only=0, .bit_length=1, .eeprom_enabled=1, .eeprom_label="grn", .eeprom_version=0},
-    {.is_read_only=0, .bit_length=1, .eeprom_enabled=1, .eeprom_label="blu", .eeprom_version=0},
+    {.is_read_only=0, .bit_length=12, .eeprom_enabled=0},
+    {.is_read_only=0, .bit_length=1, .eeprom_enabled=0},
+    {.is_read_only=0, .bit_length=1, .eeprom_enabled=0},
+    {.is_read_only=0, .bit_length=1, .eeprom_enabled=0},
 };
 // END AUTO VAR DEFS
 
@@ -300,7 +300,9 @@ bool pubVarStop(uint8_t var_id)
  * write is followed by variable data, length pre-specified for each var id
  * publish is followed by publish rate (in Hz)
  */
-void daq_command_TEST_NODE_CALLBACK(CanMsgTypeDef_t* msg_header_a)
+// BEGIN AUTO CALLBACK DEF
+void daq_command_TEST_NODE_2_CALLBACK(CanMsgTypeDef_t* msg_header_a)
+// END AUTO CALLBACK DEF
 {
 
     daq_tx_frame_writer_t tx_writer = {.data={0}, .curr_bit=0};
@@ -449,7 +451,12 @@ void flushDaqFrame(daq_tx_frame_writer_t* tx_msg)
 // send tx frame
 void sendDaqFrame(daq_tx_frame_writer_t tx_frame)
 {
-    CanMsgTypeDef_t msg = {.Bus=CAN1, .IDE=1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
+    CanMsgTypeDef_t msg = {.IDE=1, 
+    // BEGIN AUTO DAQ SEND DEF
+                           .Bus=CAN1,
+                           .ExtId=ID_DAQ_RESPONSE_TEST_NODE_2,
+    // END AUTO DAQ SEND DEF
+                           .DLC=(tx_frame.curr_bit + 7) / 8}; // rounding up
     memcpy(msg.Data, tx_frame.data, msg.DLC);
     qSendToBack(q_tx_can_a, &msg);
 }

--- a/source/l4_testing/daq/daq.h
+++ b/source/l4_testing/daq/daq.h
@@ -13,14 +13,14 @@
 
 #include <string.h>
 #include "common/phal_L4/can/can.h"
-#include "common/eeprom/eeprom.h"
 #include "can_parse.h"
+#include "common/eeprom/eeprom.h"
 
 typedef void (*read_func_ptr_t)(void* arg);
 typedef void (*write_func_ptr_t)(void* arg);
 
 // Make this match the node name within the daq_config.json
-#define NODE_NAME "TEST_NODE"
+#define NODE_NAME "TEST_NODE_2"
 
 // BEGIN AUTO VAR COUNT
 #define NUM_VARS 5
@@ -28,7 +28,8 @@ typedef void (*write_func_ptr_t)(void* arg);
 
 #define DAQ_UPDATE_PERIOD 15 // ms
 
-#define EEPROM_ENABLED 1
+#define EEPROM_ENABLED 0
+
 #define EEPROM_SIZE    4000 // bytes
 #define EEPROM_ADDR    0x50
 #define DAQ_SAVE_QUEUE_SIZE 8


### PR DESCRIPTION
Upon performing testing with multiple nodes, slight bugs were found and fixed under daq.c and daq.h. In addition, a dependency on phal was represented in the CMakeLists.txt for the eeprom repo.