### PR TITLE
CMake run python3 by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
-      - image: adambusch/per_firmware
+      - image: adambusch/per_firmware:latest
     resource_class: small
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "build",
             "type": "shell",
-            "command": "python per_build.py",
+            "command": "python3 per_build.py",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,11 +17,6 @@
             "group": "none",
             "type": "shell",
             "command": "git submodule update --init --recursive",
-            "presentation": {
-                "reveal": "always",
-                "panel": "new"
-            },
-            "runOptions": {"runOn": "folderOpen"}
         },
         { 
             "label": "can_gen",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 # Run DAQ automatic code generation
-execute_process(COMMAND python ${CMAKE_SOURCE_DIR}/common/daq/generation/generator.py 
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/common/daq/generation/generator.py 
                 RESULT_VARIABLE ret)
 if(ret EQUAL "1")
     message(FATAL_ERROR "Code Generation Failed")

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ ENV PATH $PATH:/usr/gcc-arm-none-eabi-10-2020-q4-major/bin
 
 # Install dev depenincies
 RUN apt -y install --no-install-recommends ninja-build cmake
+RUN apt -y install --no-install-recommends git ssh
 
-RUN apt -y install --no-install-recommends python3
-
-RUN apt -y install --no-install-recommends git
+# Setup python enviornment
+RUN apt -y install --no-install-recommends python3 python3-pip
+RUN apt -y install  python3-can
+RUN pip3 install --upgrade pip
+COPY ./requirements.txt /usr/requirements.txt
+RUN pip3 install --requirement /usr/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ ENV PATH $PATH:/usr/gcc-arm-none-eabi-10-2020-q4-major/bin
 RUN apt -y install --no-install-recommends ninja-build cmake
 RUN apt -y install --no-install-recommends git ssh
 
-# Setup python enviornment
-RUN apt -y install --no-install-recommends python3 python3-pip
-RUN apt -y install  python3-can
-RUN pip3 install --upgrade pip
+# Setup python virtual enviornment
+# This is required because some packages (python-can) don't get installed properly when running as root
+RUN apt -y install --no-install-recommends python3 python3.8-venv
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY ./requirements.txt /usr/requirements.txt
-RUN pip3 install --requirement /usr/requirements.txt
+RUN python3 -m pip install --requirement /usr/requirements.txt

--- a/README.md
+++ b/README.md
@@ -68,3 +68,20 @@ The "Run and Debug" window will allow for you to upload code to any firmware com
 Each pull request into the master branch will be automatically built using [CircleCI](https://app.circleci.com/pipelines/github/PurdueElectricRacing/firmware?filter=all). This build needs to pass in order for the pull request to be merged. It is important to keep the build system and docker image up to date. Future work can be put in to add software unit tests and have those block merges as well!
 
 This is an attempt at making sure that all code is able to build when pushed to the master branch.
+
+In order to update the docker image being used by CircleCI to build the firmware components you must make the necessacary changes to the Dockerfile so the firmware is able to build completley. The docker image is hosted by DockerHub, you will need to create an account there before you can push a new image.
+After the changes have been made to the Dockerfile, build the docker image with a tag by running
+```
+docker image build . -t <docker hub username>/per_firmware:latest
+```
+
+You can then push that to docker hub with
+```
+docker push <docker hub username>/per_firmware:latest
+```
+
+Make sure that image tag is being referenced in the `.circleci/config.yaml`:
+```
+    docker:
+      - image: <docker hub username>/per_firmware:latest
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
     develop:                        # Main PER docker-compose entry
         build: .                    # Specify path to Dockerfile 
-        image: stm32_develop:latest
+        image: adambusch/per_firmware:latest
         container_name: develop     # To identify which container this is 
         volumes:
             - ./:/per               # Mount our source directory to /per


### PR DESCRIPTION
Python 3 should be set as the default interpreter with the option of setting up a virtual env. 
The docker image will now accurately reflect the python requirements.txt modules for generating code