### PR TITLE
init DAQ data type update

### DIFF
--- a/common/daq/can_config.json
+++ b/common/daq/can_config.json
@@ -262,7 +262,7 @@
                         {   "msg_name":"test_msg",
                             "msg_desc":"test_msg desc",
                             "signals":[
-                                {"sig_name": "test_sig", "type":"uint16_t", "length": 16}
+                                {"sig_name": "test_sig", "type":"int16_t"}
                             ],
                             "msg_period": 15,
                             "msg_hlp": 5,
@@ -308,8 +308,8 @@
                             "msg_name":"wheel_speeds",
                             "msg_desc": "wheel speeds",
                             "signals":[
-                                {"sig_name": "left_speed", "type":"uint16_t", "length": 16},
-                                {"sig_name": "right_speed", "type":"uint16_t", "length": 16}
+                                {"sig_name": "left_speed", "type":"float", "unit":"kph"},
+                                {"sig_name": "right_speed", "type":"float", "unit":"kph"}
                             ],
                             "msg_period": 15,
                             "msg_hlp": 3,
@@ -329,6 +329,7 @@
                         }
                     ],
                     "rx":[
+                        {"msg_name": "test_msg5_2"}
                     ]
                 },
                 {
@@ -374,7 +375,9 @@
                         {   "msg_name":"test_msg5_2",
                             "msg_desc":"test_msg5 desc",
                             "signals":[
-                                {"sig_name": "test_sig5", "type":"uint16_t", "length": 16}
+                                {"sig_name": "test_sig5", "type":"uint16_t", "length": 16},
+                                {"sig_name": "test_sig5_2", "type": "int16_t"},
+                                {"sig_name": "test_sig5_3", "type": "float"}
                             ],
                             "msg_period": 15,
                             "msg_hlp": 5,

--- a/common/daq/can_schema.json
+++ b/common/daq/can_schema.json
@@ -86,19 +86,28 @@
         },
         "signal":{
             "type":"object",
-            "required":["sig_name","type","length"],
+            "required":["sig_name","type"],
             "properties":{
                 "sig_name":{"type":"string"},
+                "sig_desc":{"type":"string"},
                 "type":{
                     "type":"string",
-                    "enum":["uint8_t", "uint16_t", "uint32_t", "uint64_t"]
+                    "enum":["uint8_t", "uint16_t", "uint32_t", "uint64_t", 
+                            "int8_t", "int16_t", "int32_t", "int64_t",
+                            "float"],
+                    "description":"can only change length of uints, float defaults to 32 bits"
                 },
                 "length":{
                     "type":"integer",
-                    "description":"length in bits",
+                    "description":"length in bits, only valid if unisgned data type",
                     "minimum":1,
                     "maimum":64
-                }
+                },
+                "scale":{"type":"integer", "description":"scale factor to apply, default of 1\nDecoding results in (x * scale)+offset"},
+                "offset":{"type":"integer", "description": "offset to apply, default of 0\nDecoding results in (x * scale)+offset"},
+                "maximum":{"type":"integer", "description": "maximum value of signal, defaults to none"},
+                "minimum":{"type":"integer", "description": "minimum value of signal, defaults to none"},
+                "unit":{"type":"string", "description":"unit of the signal, defaults to none"}
             }
         },
         "rx_message":{

--- a/common/daq/generation/gen_dbc.py
+++ b/common/daq/generation/gen_dbc.py
@@ -17,20 +17,25 @@ def gen_dbc(can_config, dbc_path):
                 curr_sig_pos = 0
                 msg_signals = []
                 for sig in msg['signals']:
+
+                    # signed signals cannot have bits less than the required size
+                    # unsigned can be whatever 
+                    # floats mUsT be 32
+
                     msg_signals.append(db.Signal(name=sig['sig_name'],
                                           start=curr_sig_pos,
                                           length=sig['length'],
                                           byte_order="little_endian",
-                                          is_signed=False,
+                                          is_signed=not ('uint' in sig['type']),
                                           initial=None,
-                                          scale=1,
-                                          offset=0,
-                                          minimum=None,
-                                          maximum=None,
-                                          unit="",
-                                          comment="",
+                                          scale=1 if 'scale' not in sig else sig['scale'],
+                                          offset=0 if 'offset' not in sig else sig['offset'],
+                                          minimum=None if 'minimum' not in sig else sig['minimum'],
+                                          maximum=None if 'maximum' not in sig else sig['maximum'],
+                                          unit="" if 'unit' not in sig else sig['unit'],
+                                          comment="" if 'sig_desc' not in sig else sig['sig_desc'],
                                           is_multiplexer=False,
-                                          is_float=False,
+                                          is_float=('float' in sig['type']),
                                           decimal=None))
                     curr_sig_pos += sig['length']
 

--- a/common/daq/per_dbc.dbc
+++ b/common/daq/per_dbc.dbc
@@ -108,7 +108,7 @@ BO_ 2214624555 soc1: 2 BMS1
  SG_ soc : 0|16@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 2483028095 test_msg: 2 TEST_NODE
- SG_ test_sig : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ test_sig : 0|16@1- (1,0) [0|0] "" Vector__XXX
 
 BO_ 2483028159 test_msg2: 2 TEST_NODE
  SG_ test_sig2 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
@@ -122,9 +122,9 @@ BO_ 2483028287 test_msg4: 2 TEST_NODE
 BO_ 2483028351 test_msg5: 2 TEST_NODE
  SG_ test_sig5 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 2348810751 wheel_speeds: 4 TEST_NODE
- SG_ right_speed : 16|16@1+ (1,0) [0|0] "" Vector__XXX
- SG_ left_speed : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+BO_ 2348810751 wheel_speeds: 8 TEST_NODE
+ SG_ right_speed : 32|32@1- (1,0) [0|0] "kph" Vector__XXX
+ SG_ left_speed : 0|32@1- (1,0) [0|0] "kph" Vector__XXX
 
 BO_ 2348826559 adc_values: 5 TEST_NODE
  SG_ pot3 : 24|12@1+ (1,0) [0|0] "" Vector__XXX
@@ -146,7 +146,9 @@ BO_ 2483028221 test_msg3_2: 2 TEST_NODE_2
 BO_ 2483028285 test_msg4_2: 2 TEST_NODE_2
  SG_ test_sig4 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 2483028349 test_msg5_2: 2 TEST_NODE_2
+BO_ 2483028349 test_msg5_2: 8 TEST_NODE_2
+ SG_ test_sig5_3 : 32|32@1- (1,0) [0|0] "" Vector__XXX
+ SG_ test_sig5_2 : 16|16@1- (1,0) [0|0] "" Vector__XXX
  SG_ test_sig5 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 2550136829 daq_response_TEST_NODE_2: 8 TEST_NODE_2
@@ -173,20 +175,20 @@ CM_ BU_ TEST_NODE "";
 CM_ BU_ TEST_NODE_2 "";
 CM_ BU_ DAQ "";
 CM_ BO_ 2214592576 "Driver throttle/regeneration request";
-CM_ SG_ 2214592576 regen "";
-CM_ SG_ 2214592576 accel "";
+CM_ SG_ 2214592576 regen "regen request. 0-4096";
+CM_ SG_ 2214592576 accel "accel request. 0-4096";
 CM_ BO_ 2214598912 "Status message for main module";
-CM_ SG_ 2214598912 precharge_state "";
-CM_ SG_ 2214598912 apps_state "";
-CM_ SG_ 2214598912 car_state "";
+CM_ SG_ 2214598912 precharge_state "Precharge complete state";
+CM_ SG_ 2214598912 apps_state "Accelerator plausibility state";
+CM_ SG_ 2214598912 car_state "Main car state";
 CM_ BO_ 2214592577 "Torque request for all motors.";
-CM_ SG_ 2214592577 rear_right "";
-CM_ SG_ 2214592577 rear_left "";
-CM_ SG_ 2214592577 front_right "";
-CM_ SG_ 2214592577 front_left "";
+CM_ SG_ 2214592577 rear_right "torque request. 0-4096";
+CM_ SG_ 2214592577 rear_left "torque request. 0-4096";
+CM_ SG_ 2214592577 front_right "torque request. 0-4096";
+CM_ SG_ 2214592577 front_left "torque request. 0-4096";
 CM_ BO_ 2147490049 "Status message for bitstream flashing";
-CM_ SG_ 2147490049 flash_timeout_rx "";
-CM_ SG_ 2147490049 flash_success "";
+CM_ SG_ 2147490049 flash_timeout_rx "Timeout from CAN rx";
+CM_ SG_ 2147490049 flash_success "Done flashing bitstream";
 CM_ BO_ 2214592514 "Wheel data for the rear tires";
 CM_ SG_ 2214592514 right_normal "";
 CM_ SG_ 2214592514 left_normal "";
@@ -213,17 +215,17 @@ CM_ SG_ 2483028613 throttle0 "";
 CM_ BO_ 2214592517 "Car start button pressed";
 CM_ SG_ 2214592517 start "";
 CM_ BO_ 2415925566 "Bitstream download command";
-CM_ SG_ 2415925566 d7 "";
-CM_ SG_ 2415925566 d6 "";
-CM_ SG_ 2415925566 d5 "";
-CM_ SG_ 2415925566 d4 "";
-CM_ SG_ 2415925566 d3 "";
-CM_ SG_ 2415925566 d2 "";
-CM_ SG_ 2415925566 d1 "";
-CM_ SG_ 2415925566 d0 "";
+CM_ SG_ 2415925566 d7 "Bitstream data word 7";
+CM_ SG_ 2415925566 d6 "Bitstream data word 6";
+CM_ SG_ 2415925566 d5 "Bitstream data word 5";
+CM_ SG_ 2415925566 d4 "Bitstream data word 4";
+CM_ SG_ 2415925566 d3 "Bitstream data word 3";
+CM_ SG_ 2415925566 d2 "Bitstream data word 2";
+CM_ SG_ 2415925566 d1 "Bitstream data word 1";
+CM_ SG_ 2415925566 d0 "Bitstream data word 0";
 CM_ BO_ 2415925630 "Bitstream state command";
-CM_ SG_ 2415925630 download_size "";
-CM_ SG_ 2415925630 download_request "";
+CM_ SG_ 2415925630 download_size "size for expected bitstream download (bytes)";
+CM_ SG_ 2415925630 download_request "Request to download new bitstream";
 CM_ BO_ 2214624554 "Request BMSs to discharge their cells to the desired voltage";
 CM_ SG_ 2214624554 volts "";
 CM_ BO_ 2214624555 "Estimated soc";
@@ -256,6 +258,8 @@ CM_ SG_ 2483028221 test_sig3 "";
 CM_ BO_ 2483028285 "test_msg4 desc";
 CM_ SG_ 2483028285 test_sig4 "";
 CM_ BO_ 2483028349 "test_msg5 desc";
+CM_ SG_ 2483028349 test_sig5_3 "";
+CM_ SG_ 2483028349 test_sig5_2 "";
 CM_ SG_ 2483028349 test_sig5 "";
 CM_ BO_ 2550136829 "daq response from node TEST_NODE_2";
 CM_ SG_ 2550136829 daq_response "";
@@ -267,6 +271,8 @@ CM_ SG_ 2483031922 daq_command "";
 
 
 
-
+SIG_VALTYPE_ 2348810751 left_speed : 1;
+SIG_VALTYPE_ 2348810751 right_speed : 1;
+SIG_VALTYPE_ 2483028349 test_sig5_3 : 1;
 
 

--- a/source/l4_testing/can/can_parse.c
+++ b/source/l4_testing/can/can_parse.c
@@ -37,6 +37,13 @@ void canRxUpdate()
         /* BEGIN AUTO CASES */
         switch(msg_header.ExtId)
         {
+            case ID_TEST_MSG5_2:
+                can_data.test_msg5_2.test_sig5 = msg_data_a->test_msg5_2.test_sig5;
+                can_data.test_msg5_2.test_sig5_2 = (int16_t) msg_data_a->test_msg5_2.test_sig5_2;
+                can_data.test_msg5_2.test_sig5_3 = UINT32_TO_FLOAT(msg_data_a->test_msg5_2.test_sig5_3);
+                can_data.test_msg5_2.stale = 0;
+                can_data.test_msg5_2.last_rx = curr_tick;
+                break;
             case ID_DAQ_COMMAND_TEST_NODE:
                 can_data.daq_command_TEST_NODE.daq_command = msg_data_a->daq_command_TEST_NODE.daq_command;
                 daq_command_TEST_NODE_CALLBACK(&msg_header);
@@ -48,6 +55,9 @@ void canRxUpdate()
     }
 
     /* BEGIN AUTO STALE CHECKS */
+    CHECK_STALE(can_data.test_msg5_2.stale,
+                curr_tick, can_data.test_msg5_2.last_rx,
+                UP_TEST_MSG5_2);
     /* END AUTO STALE CHECKS */
 }
 
@@ -66,7 +76,8 @@ bool initCANFilter()
 
     /* BEGIN AUTO FILTER */
     CAN1->FA1R |= (1 << 0);    // configure bank 0
-    CAN1->sFilterRegister[0].FR1 = (ID_DAQ_COMMAND_TEST_NODE << 3) | 4;
+    CAN1->sFilterRegister[0].FR1 = (ID_TEST_MSG5_2 << 3) | 4;
+    CAN1->sFilterRegister[0].FR2 = (ID_DAQ_COMMAND_TEST_NODE << 3) | 4;
     /* END AUTO FILTER */
 
     CAN1->FMR  &= ~CAN_FMR_FINIT;             // Enable Filters (exit filter init mode)

--- a/source/l4_testing/main.c
+++ b/source/l4_testing/main.c
@@ -239,7 +239,7 @@ uint16_t adc_reading = 0;
 
 void canSendTest()
 {
-    SEND_TEST_MSG(q_tx_can, (uint16_t) (500 * sin(((double) counter)/100) + 501));
+    SEND_TEST_MSG(q_tx_can, (int16_t) (500 * sin(((double) counter)/100)));
     SEND_TEST_MSG2(q_tx_can, counter2);
 
     counter += 1;

--- a/source/l4_testing/wheel_speeds/wheel_speeds.c
+++ b/source/l4_testing/wheel_speeds/wheel_speeds.c
@@ -39,11 +39,9 @@ void wheelSpeedsInit()
 
 void wheelSpeedsPeriodic()
 {
-    // TODO: convert to wheel speed instead of frequency
-    // ensure that the conversion does not loose significant figures
-    wheel_speeds.left.freq_hz = TIM_CLOCK_FREQ / left_ccr;
-    wheel_speeds.right.freq_hz = TIM_CLOCK_FREQ / right_ccr;
-    SEND_WHEEL_SPEEDS(q_tx_can, (uint16_t) wheel_speeds.left.freq_hz, (uint16_t) wheel_speeds.right.freq_hz);
+    wheel_speeds.left.freq_hz = FREQ_TO_KPH * TIM_CLOCK_FREQ / (float) left_ccr;
+    wheel_speeds.right.freq_hz = FREQ_TO_KPH * TIM_CLOCK_FREQ / (float) right_ccr;
+    SEND_WHEEL_SPEEDS(q_tx_can, wheel_speeds.left.freq_hz, wheel_speeds.right.freq_hz);
 }
 
 uint32_t left_ccr_msb_counter = 0;

--- a/source/l4_testing/wheel_speeds/wheel_speeds.h
+++ b/source/l4_testing/wheel_speeds/wheel_speeds.h
@@ -28,12 +28,18 @@
  */
 #define TIM_CLOCK_FREQ 2000000
 
+#define WHEEL_DIAM_M 0.4572
+#define WHEEL_CIRCUMF_M (3.14159 * WHEEL_DIAM_M)
+#define SENSOR_TEETH 32
+#define MPS_TO_KPH 3.6
+#define FREQ_TO_KPH (MPS_TO_KPH * WHEEL_CIRCUMF_M / SENSOR_TEETH)
+
 typedef struct {
   struct {
-    uint16_t freq_hz;
+    float freq_hz;
   } left;
   struct {
-    uint16_t freq_hz;
+    float freq_hz;
   } right;
 } WheelSpeeds_t;
 


### PR DESCRIPTION
Added signed integer types and floats. 
The signal bit length is only specifiable when the data type is unsigned and floats default to 32 bits.
In addition, more signal parameters can be added such as scale, offset, minimum, maximum, and units.
The scaling and offset are applied as (x * scale) / offset whenever the message is decoded.
However, they are not automatically applied whenever you send the message.
In addition, the units are displayed in the DAQ app under the frame viewer and plot axis labels.