### PR TITLE
Add task 'stats'

### DIFF
--- a/common/psched/psched.c
+++ b/common/psched/psched.c
@@ -268,7 +268,7 @@ static void memsetu(uint8_t* ptr, uint8_t val, size_t size)
 // @brief: Runs actual calculation
 static void statsHelper(time_stats_t* stats)
 {
-    uint16_t ttime;
+    int16_t ttime;
 
     if (stats->entry_time_ticks != stats->exit_time_ticks)
     {

--- a/common/psched/psched.h
+++ b/common/psched/psched.h
@@ -14,39 +14,53 @@
     #error "Please define a MCU arch"
 #endif
 
+#define MAX_TASK        15
+#define CPU_HIGH        90
+#define CPU_MID         75
+
 #define toMicros(time) ((uint32_t) time * 1000)
 
 // Structs, Enums, Types
 enum {
-    TASK,
+    TASK_FG,
     TASK_BG
 };
 
 typedef void (*func_ptr_t)(void);
 
 typedef struct {
-    uint16_t task_time;                 // Time spent in a task
-    uint16_t bg_time;                   // Time spent in bg loop
-    uint32_t task_entry_time;           // Tick time of task entry
-    uint32_t bg_entry_time;             // Tick time of background entry
-    float    cpu_use;                   // % use of task time
+    uint32_t entry_time_ticks;              // Entry time in OS ticks
+    uint32_t exit_time_ticks;               // Exit time in OS ticks
+    uint16_t entry_time_cnt;                // Entry time in counter LSB
+    uint16_t exit_time_cnt;                 // Exit time in counter LSB
+    float    cpu_use;                       // %age of CPU use by this entity
+} time_stats_t;
+
+typedef struct {
+    time_stats_t fg_stats;                  // Foreground loop stats
+    time_stats_t bg_stats;                  // Background loop stats
 } cpu_t;
 
 typedef struct
 {
-    uint8_t    skips;                   // Number of loop misses. Execution time was skipped. Should always be 0
-    uint8_t    run_next;                // Triggers background to run next iteration
-    uint8_t    task_count;              // Number of tasks
-    uint8_t    bg_count;                // Number of background tasks
-    uint8_t    running;                 // Marks scheduler as running
-    uint32_t   os_ticks;                // Current OS tick count
-    uint32_t   of;                      // MCU operating frequency
+    uint8_t      llevel;                    // Logging level
+    uint8_t      handler_set;               // Flag for exception handler function
+    uint8_t      skips;                     // Number of loop misses. Execution time was skipped. Should always be 0
+    uint8_t      run_next;                  // Triggers background to run next iteration
+    uint8_t      task_count;                // Number of tasks
+    uint8_t      bg_count;                  // Number of background tasks
+    uint8_t      running;                   // Marks scheduler as running
+    uint32_t     os_ticks;                  // Current OS tick count
+    uint32_t     of;                        // MCU operating frequency
 
-    uint16_t   task_time[15];           // Timings of registered tasks
-    func_ptr_t task_pointer[15];        // Function pointers to tasks
-    func_ptr_t bg_pointer[15];          // Function pointers to background tasks
+    uint16_t     task_time[MAX_TASK];       // Task interval in ms
+    func_ptr_t   task_pointer[MAX_TASK];    // Function pointers to tasks
+    func_ptr_t   bg_pointer[MAX_TASK];      // Function pointers to background tasks
+    func_ptr_t   exception_handler;         // Function pointer to exception handler
 
-    cpu_t    core;
+    time_stats_t fg_task_stats[MAX_TASK];   // Foreground task stats
+
+    cpu_t    core;                          // Overall loop stats
 } sched_t;
 
 extern sched_t sched;
@@ -54,9 +68,10 @@ extern sched_t sched;
 // Prototypes
 void taskCreate(func_ptr_t func, uint16_t task_time);
 void taskCreateBackground(func_ptr_t func);
+void setLogging(uint8_t level, func_ptr_t handler);
 void taskDelete(uint8_t type, uint8_t task);
 void schedInit(uint32_t freq);
-void schedStart();
-void schedPause();
+void schedStart(void);
+void schedPause(void);
 
 #endif


### PR DESCRIPTION
Added computation of CPU time. If a task is responsible for blowing through the 1ms barrier, it's marked as 100%. It isn't a perfect solution since a previous task could have taken 0.99ms with the final task blowing through, but successive calls to sched.exception_handler() [assuming they're dumped to the CAN bus] will show which task is the problem. Stuff isn't tested quite yet, but I'll update with more once it is