### PR TITLE
move can parse to a background task

### DIFF
--- a/common/daq/can_config.json
+++ b/common/daq/can_config.json
@@ -328,7 +328,8 @@
                         }
                     ],
                     "rx":[
-                        {"msg_name": "test_msg5_2"}
+                        {"msg_name": "test_msg5_2"},
+                        {"msg_name": "test_stale"}
                     ]
                 },
                 {
@@ -381,6 +382,15 @@
                             "msg_period": 15,
                             "msg_hlp": 5,
                             "msg_pgn": 5 
+                        },
+                        {
+                            "msg_name":"test_stale",
+                            "msg_desc":"used to test stale",
+                            "signals":[
+                                {"sig_name":"data", "type":"uint8_t", "length": 8}
+                            ],
+                            "msg_period":1000,
+                            "msg_id_override": "0x2222"
                         }
                     ],
                     "rx":[

--- a/common/daq/generation/gen_embedded_can.py
+++ b/common/daq/generation/gen_embedded_can.py
@@ -106,7 +106,7 @@ def gen_switch_case(lines, rx_msg_configs, rx_callbacks, ind=""):
             lines.append(ind+f"                can_data.{msg['msg_name']}.{sig['sig_name']} = {convert_str};\n")
         if msg['msg_period'] > 0:
             lines.append(ind+f"                can_data.{msg['msg_name']}.stale = 0;\n")
-            lines.append(ind+f"                can_data.{msg['msg_name']}.last_rx = curr_tick;\n")
+            lines.append(ind+f"                can_data.{msg['msg_name']}.last_rx = sched.os_ticks;\n")
         callback = [rx_config for rx_config in rx_callbacks if rx_config['msg_name'] == msg['msg_name']]
         if callback:
             if "arg_type" in callback[0] and callback[0]['arg_type'] == "header":
@@ -268,7 +268,7 @@ def configure_node(node_config, node_paths):
     for msg in receiving_msg_defs:
         if msg['msg_period'] > 0:
             stale_lines.append(f"    CHECK_STALE(can_data.{msg['msg_name']}.stale,\n")
-            stale_lines.append(f"                curr_tick, can_data.{msg['msg_name']}.last_rx,\n")
+            stale_lines.append(f"                sched.os_ticks, can_data.{msg['msg_name']}.last_rx,\n")
             stale_lines.append(f"                UP_{msg['msg_name'].upper()});\n")
     c_lines = generator.insert_lines(c_lines, gen_stale_case_start, gen_stale_case_stop, stale_lines)
 

--- a/common/daq/per_dbc.dbc
+++ b/common/daq/per_dbc.dbc
@@ -126,7 +126,7 @@ BO_ 2348810751 wheel_speeds: 8 TEST_NODE
  SG_ right_speed : 32|32@1- (1,0) [0|0] "kph" Vector__XXX
  SG_ left_speed : 0|32@1- (1,0) [0|0] "kph" Vector__XXX
 
-BO_ 2147484882 adc_values: 5 TEST_NODE
+BO_ 2147488308 adc_values: 5 TEST_NODE
  SG_ pot3 : 24|12@1+ (1,0) [0|0] "" Vector__XXX
  SG_ pot2 : 12|12@1+ (1,0) [0|0] "" Vector__XXX
  SG_ pot1 : 0|12@1+ (1,0) [0|0] "" Vector__XXX
@@ -150,6 +150,9 @@ BO_ 2483028349 test_msg5_2: 8 TEST_NODE_2
  SG_ test_sig5_3 : 32|32@1- (1,0) [0|0] "" Vector__XXX
  SG_ test_sig5_2 : 16|16@1- (1,0) [0|0] "" Vector__XXX
  SG_ test_sig5 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2147492386 test_stale: 1 TEST_NODE_2
+ SG_ data : 0|8@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 2550136829 daq_response_TEST_NODE_2: 8 TEST_NODE_2
  SG_ daq_response : 0|64@1+ (1,0) [0|0] "" Vector__XXX
@@ -243,10 +246,10 @@ CM_ SG_ 2483028351 test_sig5 "";
 CM_ BO_ 2348810751 "wheel speeds";
 CM_ SG_ 2348810751 right_speed "";
 CM_ SG_ 2348810751 left_speed "";
-CM_ BO_ 2147484882 "adc potentiometer readings";
-CM_ SG_ 2147484882 pot3 "";
-CM_ SG_ 2147484882 pot2 "";
-CM_ SG_ 2147484882 pot1 "";
+CM_ BO_ 2147488308 "adc potentiometer readings";
+CM_ SG_ 2147488308 pot3 "";
+CM_ SG_ 2147488308 pot2 "";
+CM_ SG_ 2147488308 pot1 "";
 CM_ BO_ 2550136831 "daq response from node TEST_NODE";
 CM_ SG_ 2550136831 daq_response "";
 CM_ BO_ 2483028093 "test_msg desc";
@@ -261,6 +264,8 @@ CM_ BO_ 2483028349 "test_msg5 desc";
 CM_ SG_ 2483028349 test_sig5_3 "";
 CM_ SG_ 2483028349 test_sig5_2 "";
 CM_ SG_ 2483028349 test_sig5 "";
+CM_ BO_ 2147492386 "used to test stale";
+CM_ SG_ 2147492386 data "";
 CM_ BO_ 2550136829 "daq response from node TEST_NODE_2";
 CM_ SG_ 2550136829 daq_response "";
 CM_ BO_ 2483032050 "daq command for node TEST_NODE";

--- a/common/daq/templates/can_parse_template.c
+++ b/common/daq/templates/can_parse_template.c
@@ -22,12 +22,8 @@ void initCANParse(q_handle_t* rx_a)
     initCANFilter();
 }
 
-uint32_t curr_tick = 0;
-
 void canRxUpdate()
 {
-    curr_tick += 1;
-
     CanMsgTypeDef_t msg_header;
     CanParsedData_t* msg_data_a;
 

--- a/common/daq/templates/can_parse_template.h
+++ b/common/daq/templates/can_parse_template.h
@@ -12,12 +12,11 @@
 #define _CAN_PARSE_H_
 
 #include "common/queue/queue.h"
+#include "common/psched/psched.h"
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
 #define NODE_NAME "TEMPLATE_NODE"
-
-#define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
@@ -37,7 +36,7 @@
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
-                    (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+                    (curr - last) > period * STALE_THRESH) stale = 1
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */

--- a/common/psched/psched.c
+++ b/common/psched/psched.c
@@ -255,7 +255,7 @@ void schedPause(void)
 static void memsetu(uint8_t* ptr, uint8_t val, size_t size)
 {
     // Locals
-    uint8_t i;
+    size_t i;
 
     for (i = 0; i < size; i++)
     {

--- a/source/dashboard/can/can_parse.c
+++ b/source/dashboard/can/can_parse.c
@@ -22,12 +22,8 @@ void initCANParse(q_handle_t* rx_a)
     initCANFilter();
 }
 
-uint32_t curr_tick = 0;
-
 void canRxUpdate()
 {
-    curr_tick += 1;
-
     CanMsgTypeDef_t msg_header;
     CanParsedData_t* msg_data_a;
 
@@ -42,7 +38,7 @@ void canRxUpdate()
                 can_data.main_status.apps_state = msg_data_a->main_status.apps_state;
                 can_data.main_status.precharge_state = msg_data_a->main_status.precharge_state;
                 can_data.main_status.stale = 0;
-                can_data.main_status.last_rx = curr_tick;
+                can_data.main_status.last_rx = sched.os_ticks;
                 break;
             default:
                 __asm__("nop");
@@ -52,7 +48,7 @@ void canRxUpdate()
 
     /* BEGIN AUTO STALE CHECKS */
     CHECK_STALE(can_data.main_status.stale,
-                curr_tick, can_data.main_status.last_rx,
+                sched.os_ticks, can_data.main_status.last_rx,
                 UP_MAIN_STATUS);
     /* END AUTO STALE CHECKS */
 }

--- a/source/dashboard/can/can_parse.h
+++ b/source/dashboard/can/can_parse.h
@@ -12,12 +12,11 @@
 #define _CAN_PARSE_H_
 
 #include "common/queue/queue.h"
+#include "common/psched/psched.h"
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
 #define NODE_NAME "Dashboard"
-
-#define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
@@ -59,7 +58,7 @@
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
-                    (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+                    (curr - last) > period * STALE_THRESH) stale = 1
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */

--- a/source/driveline/can/can_parse.c
+++ b/source/driveline/can/can_parse.c
@@ -22,12 +22,8 @@ void initCANParse(q_handle_t* rx_a)
     initCANFilter();
 }
 
-uint32_t curr_tick = 0;
-
 void canRxUpdate()
 {
-    curr_tick += 1;
-
     CanMsgTypeDef_t msg_header;
     CanParsedData_t* msg_data_a;
 
@@ -43,7 +39,7 @@ void canRxUpdate()
                 can_data.torque_request.rear_left = msg_data_a->torque_request.rear_left;
                 can_data.torque_request.rear_right = msg_data_a->torque_request.rear_right;
                 can_data.torque_request.stale = 0;
-                can_data.torque_request.last_rx = curr_tick;
+                can_data.torque_request.last_rx = sched.os_ticks;
                 break;
             default:
                 __asm__("nop");
@@ -53,7 +49,7 @@ void canRxUpdate()
 
     /* BEGIN AUTO STALE CHECKS */
     CHECK_STALE(can_data.torque_request.stale,
-                curr_tick, can_data.torque_request.last_rx,
+                sched.os_ticks, can_data.torque_request.last_rx,
                 UP_TORQUE_REQUEST);
     /* END AUTO STALE CHECKS */
 }

--- a/source/driveline/can/can_parse.h
+++ b/source/driveline/can/can_parse.h
@@ -12,12 +12,11 @@
 #define _CAN_PARSE_H_
 
 #include "common/queue/queue.h"
+#include "common/psched/psched.h"
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
 #define NODE_NAME "Driveline"
-
-#define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
@@ -80,7 +79,7 @@
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
-                    (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+                    (curr - last) > period * STALE_THRESH) stale = 1
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */

--- a/source/l4_testing/can/can_parse.c
+++ b/source/l4_testing/can/can_parse.c
@@ -22,12 +22,8 @@ void initCANParse(q_handle_t* rx_a)
     initCANFilter();
 }
 
-uint32_t curr_tick = 0;
-
 void canRxUpdate()
 {
-    curr_tick += 1;
-
     CanMsgTypeDef_t msg_header;
     CanParsedData_t* msg_data_a;
 
@@ -42,7 +38,12 @@ void canRxUpdate()
                 can_data.test_msg5_2.test_sig5_2 = (int16_t) msg_data_a->test_msg5_2.test_sig5_2;
                 can_data.test_msg5_2.test_sig5_3 = UINT32_TO_FLOAT(msg_data_a->test_msg5_2.test_sig5_3);
                 can_data.test_msg5_2.stale = 0;
-                can_data.test_msg5_2.last_rx = curr_tick;
+                can_data.test_msg5_2.last_rx = sched.os_ticks;
+                break;
+            case ID_TEST_STALE:
+                can_data.test_stale.data = msg_data_a->test_stale.data;
+                can_data.test_stale.stale = 0;
+                can_data.test_stale.last_rx = sched.os_ticks;
                 break;
             case ID_DAQ_COMMAND_TEST_NODE:
                 can_data.daq_command_TEST_NODE.daq_command = msg_data_a->daq_command_TEST_NODE.daq_command;
@@ -56,8 +57,11 @@ void canRxUpdate()
 
     /* BEGIN AUTO STALE CHECKS */
     CHECK_STALE(can_data.test_msg5_2.stale,
-                curr_tick, can_data.test_msg5_2.last_rx,
+                sched.os_ticks, can_data.test_msg5_2.last_rx,
                 UP_TEST_MSG5_2);
+    CHECK_STALE(can_data.test_stale.stale,
+                sched.os_ticks, can_data.test_stale.last_rx,
+                UP_TEST_STALE);
     /* END AUTO STALE CHECKS */
 }
 
@@ -77,7 +81,9 @@ bool initCANFilter()
     /* BEGIN AUTO FILTER */
     CAN1->FA1R |= (1 << 0);    // configure bank 0
     CAN1->sFilterRegister[0].FR1 = (ID_TEST_MSG5_2 << 3) | 4;
-    CAN1->sFilterRegister[0].FR2 = (ID_DAQ_COMMAND_TEST_NODE << 3) | 4;
+    CAN1->sFilterRegister[0].FR2 = (ID_TEST_STALE << 3) | 4;
+    CAN1->FA1R |= (1 << 1);    // configure bank 1
+    CAN1->sFilterRegister[1].FR1 = (ID_DAQ_COMMAND_TEST_NODE << 3) | 4;
     /* END AUTO FILTER */
 
     CAN1->FMR  &= ~CAN_FMR_FINIT;             // Enable Filters (exit filter init mode)

--- a/source/l4_testing/can/can_parse.h
+++ b/source/l4_testing/can/can_parse.h
@@ -12,13 +12,12 @@
 #define _CAN_PARSE_H_
 
 #include "common/queue/queue.h"
+#include "common/psched/psched.h"
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
 
 #define NODE_NAME "TEST_NODE"
-
-#define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
@@ -28,9 +27,10 @@
 #define ID_TEST_MSG4 0x1400013f
 #define ID_TEST_MSG5 0x1400017f
 #define ID_WHEEL_SPEEDS 0xc0001ff
-#define ID_ADC_VALUES 0x4d2
+#define ID_ADC_VALUES 0x1234
 #define ID_DAQ_RESPONSE_TEST_NODE 0x17ffffff
 #define ID_TEST_MSG5_2 0x1400017d
+#define ID_TEST_STALE 0x2222
 #define ID_DAQ_COMMAND_TEST_NODE 0x14000ff2
 /* END AUTO ID DEFS */
 
@@ -45,6 +45,7 @@
 #define DLC_ADC_VALUES 5
 #define DLC_DAQ_RESPONSE_TEST_NODE 8
 #define DLC_TEST_MSG5_2 8
+#define DLC_TEST_STALE 1
 #define DLC_DAQ_COMMAND_TEST_NODE 8
 /* END AUTO DLC DEFS */
 
@@ -113,12 +114,13 @@ typedef union {
 
 // Stale Checking
 #define STALE_THRESH 3 / 2 // 3 / 2 would be 150% of period
-/* BEGIN AUTO UP DEFS (Update Period)*/
+/* BEGIN AUTO UP DEFS (Update Period) in milliseconds*/
 #define UP_TEST_MSG5_2 15
+#define UP_TEST_STALE 1000
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
-                    (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+                    (curr - last) > period * STALE_THRESH) stale = 1
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
@@ -156,6 +158,9 @@ typedef union { __attribute__((packed))
         uint64_t test_sig5_3: 32;
     } test_msg5_2;
     struct {
+        uint64_t data: 8;
+    } test_stale;
+    struct {
         uint64_t daq_command: 64;
     } daq_command_TEST_NODE;
     uint8_t raw_data[8];
@@ -173,6 +178,11 @@ typedef struct {
         uint8_t stale;
         uint32_t last_rx;
     } test_msg5_2;
+    struct {
+        uint8_t data;
+        uint8_t stale;
+        uint32_t last_rx;
+    } test_stale;
     struct {
         uint64_t daq_command;
     } daq_command_TEST_NODE;

--- a/source/l4_testing/main.c
+++ b/source/l4_testing/main.c
@@ -172,12 +172,12 @@ int main (void)
     schedInit(SystemCoreClock);
     taskCreate(ledBlink, 500);
     taskCreate(adcConvert, 50);
-    taskCreate(canRxUpdate, RX_UPDATE_PERIOD);
     taskCreate(daqPeriodic, DAQ_UPDATE_PERIOD);
     taskCreate(canSendTest, 50);
     taskCreate(wheelSpeedsPeriodic, 15);
     //taskCreate(myCounterTest, 50);
     taskCreateBackground(canTxUpdate);
+    taskCreateBackground(canRxUpdate);
 
     // signify end of initialization
     PHAL_writeGPIO(LED_GREEN_GPIO_Port, LED_GREEN_Pin, 0);
@@ -196,7 +196,15 @@ void adcConvert()
 
 void ledBlink()
 {
-    PHAL_toggleGPIO(LED_BLUE_GPIO_Port, LED_BLUE_Pin);
+    if (can_data.test_stale.stale)
+    {
+        PHAL_writeGPIO(LED_GREEN_GPIO_Port, LED_GREEN_Pin, true);
+    }
+    else
+    {
+        PHAL_writeGPIO(LED_GREEN_GPIO_Port, LED_GREEN_Pin, false);
+    }
+    //PHAL_toggleGPIO(LED_BLUE_GPIO_Port, LED_BLUE_Pin);
 }
 
 void myCounterTest()

--- a/source/main_module/can/can_parse.c
+++ b/source/main_module/can/can_parse.c
@@ -22,12 +22,8 @@ void initCANParse(q_handle_t* rx_a)
     initCANFilter();
 }
 
-uint32_t curr_tick = 0;
-
 void canRxUpdate()
 {
-    curr_tick += 1;
-
     CanMsgTypeDef_t msg_header;
     CanParsedData_t* msg_data_a;
 
@@ -43,7 +39,7 @@ void canRxUpdate()
                 can_data.raw_throttle_brake.brake0 = msg_data_a->raw_throttle_brake.brake0;
                 can_data.raw_throttle_brake.brake1 = msg_data_a->raw_throttle_brake.brake1;
                 can_data.raw_throttle_brake.stale = 0;
-                can_data.raw_throttle_brake.last_rx = curr_tick;
+                can_data.raw_throttle_brake.last_rx = sched.os_ticks;
                 break;
             case ID_START_BUTTON:
                 can_data.start_button.start = msg_data_a->start_button.start;
@@ -57,7 +53,7 @@ void canRxUpdate()
 
     /* BEGIN AUTO STALE CHECKS */
     CHECK_STALE(can_data.raw_throttle_brake.stale,
-                curr_tick, can_data.raw_throttle_brake.last_rx,
+                sched.os_ticks, can_data.raw_throttle_brake.last_rx,
                 UP_RAW_THROTTLE_BRAKE);
     /* END AUTO STALE CHECKS */
 }

--- a/source/main_module/can/can_parse.h
+++ b/source/main_module/can/can_parse.h
@@ -12,12 +12,11 @@
 #define _CAN_PARSE_H_
 
 #include "common/queue/queue.h"
+#include "common/psched/psched.h"
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
 #define NODE_NAME "Main_Module"
-
-#define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
@@ -61,7 +60,7 @@
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
-                    (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+                    (curr - last) > period * STALE_THRESH) stale = 1
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */

--- a/source/precharge/can/can_parse.c
+++ b/source/precharge/can/can_parse.c
@@ -22,12 +22,8 @@ void initCANParse(q_handle_t* rx_a)
     initCANFilter();
 }
 
-uint32_t curr_tick = 0;
-
 void canRxUpdate()
 {
-    curr_tick += 1;
-
     CanMsgTypeDef_t msg_header;
     CanParsedData_t* msg_data_a;
 

--- a/source/precharge/can/can_parse.h
+++ b/source/precharge/can/can_parse.h
@@ -12,12 +12,11 @@
 #define _CAN_PARSE_H_
 
 #include "common/queue/queue.h"
+#include "common/psched/psched.h"
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
 #define NODE_NAME "Precharge"
-
-#define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
@@ -55,7 +54,7 @@
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
-                    (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+                    (curr - last) > period * STALE_THRESH) stale = 1
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */

--- a/source/precharge/main.c
+++ b/source/precharge/main.c
@@ -133,9 +133,10 @@ int main (void)
 
     /* Task Creation */
     schedInit(SystemCoreClock);
-    taskCreate(canRxUpdate, RX_UPDATE_PERIOD);
-    taskCreate(canTxUpdate, 5);
     taskCreate(heartbeat_task, 1000);
+
+    taskCreateBackground(canTxUpdate);
+    taskCreateBackground(canRxUpdate);
 
     /* No Way Home */
     schedStart();

--- a/source/torque_vector/can/can_parse.c
+++ b/source/torque_vector/can/can_parse.c
@@ -22,12 +22,8 @@ void initCANParse(q_handle_t* rx_a)
     initCANFilter();
 }
 
-uint32_t curr_tick = 0;
-
 void canRxUpdate()
 {
-    curr_tick += 1;
-
     CanMsgTypeDef_t msg_header;
     CanParsedData_t* msg_data_a;
 

--- a/source/torque_vector/can/can_parse.h
+++ b/source/torque_vector/can/can_parse.h
@@ -12,12 +12,11 @@
 #define _CAN_PARSE_H_
 
 #include "common/queue/queue.h"
+#include "common/psched/psched.h"
 #include "common/phal_L4/can/can.h"
 
 // Make this match the node name within the can_config.json
 #define NODE_NAME "TORQUE_VECTOR"
-
-#define RX_UPDATE_PERIOD 15 // ms
 
 // Message ID definitions
 /* BEGIN AUTO ID DEFS */
@@ -61,7 +60,7 @@
 /* END AUTO UP DEFS */
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
-                    (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+                    (curr - last) > period * STALE_THRESH) stale = 1
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */

--- a/source/torque_vector/main.c
+++ b/source/torque_vector/main.c
@@ -95,10 +95,10 @@ int main (void)
 
     /* Task Creation */
     schedInit(SystemCoreClock);
-    taskCreate(canRxUpdate, RX_UPDATE_PERIOD);
-    taskCreate(canTxUpdate, 5);
     taskCreate(bitstream10Hz, 100);
     taskCreate(bitstream100Hz, 10);
+    taskCreateBackground(canTxUpdate);
+    taskCreateBackground(canRxUpdate);
     schedStart();
 
     return 0;


### PR DESCRIPTION
Modifying the receiving of can messages so that it is based on the os_ticks from psched for stale checking, and can be ran at any frequency. That way can tx and rx are background tasks and can blaze as fast as possible. Also, modified the memsetu loop index variable from a uint8_t to a size_t (it got stuck in an infinite loop since size was larger than 2^8).