### PR TITLE
add can enums

### DIFF
--- a/common/daq/can_config.json
+++ b/common/daq/can_config.json
@@ -325,10 +325,20 @@
                             ],
                             "msg_period": 15,
                             "msg_id_override": "0x00001234"
+                        },
+                        {
+                            "msg_name":"car_state",
+                            "msg_desc": "state of the car",
+                            "signals":[
+                                {"sig_name":"car_state", "type":"uint8_t", "length": 8, "choices":["ready2go","flipped","flying","lightspeed"]}
+                            ],
+                            "msg_period":0,
+                            "msg_id_override": "0xBEEF420"
                         }
                     ],
                     "rx":[
-                        {"msg_name": "test_msg5_2"}
+                        {"msg_name": "test_msg5_2"},
+                        {"msg_name": "car_state2"}
                     ]
                 },
                 {
@@ -381,6 +391,15 @@
                             "msg_period": 15,
                             "msg_hlp": 5,
                             "msg_pgn": 5 
+                        },
+                        {
+                            "msg_name":"car_state2",
+                            "msg_desc": "state of the car",
+                            "signals":[
+                                {"sig_name":"car_state2", "type":"uint8_t", "length": 8, "choices":["ready2go","flipped","flying","lightspeed"]}
+                            ],
+                            "msg_period":0,
+                            "msg_id_override": "0xBEEF421"
                         }
                     ],
                     "rx":[

--- a/common/daq/can_schema.json
+++ b/common/daq/can_schema.json
@@ -110,7 +110,8 @@
                 "offset":{"type":"integer", "description": "offset to apply, default of 0\nDecoding results in (x * scale)+offset"},
                 "maximum":{"type":"integer", "description": "maximum value of signal, defaults to none"},
                 "minimum":{"type":"integer", "description": "minimum value of signal, defaults to none"},
-                "unit":{"type":"string", "description":"unit of the signal, defaults to none"}
+                "unit":{"type":"string", "description":"unit of the signal, defaults to none"},
+                "choices":{"type":"array", "description":"enumeration values", "items":{"type":"string"}}
             }
         },
         "rx_message":{

--- a/common/daq/generation/gen_dbc.py
+++ b/common/daq/generation/gen_dbc.py
@@ -34,6 +34,7 @@ def gen_dbc(can_config, dbc_path):
                                           maximum=None if 'maximum' not in sig else sig['maximum'],
                                           unit="" if 'unit' not in sig else sig['unit'],
                                           comment="" if 'sig_desc' not in sig else sig['sig_desc'],
+                                          choices=None if 'choices' not in sig else {i:choice for i, choice in enumerate(sig['choices'])},
                                           is_multiplexer=False,
                                           is_float=('float' in sig['type']),
                                           decimal=None))

--- a/common/daq/per_dbc.dbc
+++ b/common/daq/per_dbc.dbc
@@ -126,10 +126,13 @@ BO_ 2348810751 wheel_speeds: 8 TEST_NODE
  SG_ right_speed : 32|32@1- (1,0) [0|0] "kph" Vector__XXX
  SG_ left_speed : 0|32@1- (1,0) [0|0] "kph" Vector__XXX
 
-BO_ 2147484882 adc_values: 5 TEST_NODE
+BO_ 2147488308 adc_values: 5 TEST_NODE
  SG_ pot3 : 24|12@1+ (1,0) [0|0] "" Vector__XXX
  SG_ pot2 : 12|12@1+ (1,0) [0|0] "" Vector__XXX
  SG_ pot1 : 0|12@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2347693088 car_state: 1 TEST_NODE
+ SG_ car_state : 0|8@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 2550136831 daq_response_TEST_NODE: 8 TEST_NODE
  SG_ daq_response : 0|64@1+ (1,0) [0|0] "" Vector__XXX
@@ -150,6 +153,9 @@ BO_ 2483028349 test_msg5_2: 8 TEST_NODE_2
  SG_ test_sig5_3 : 32|32@1- (1,0) [0|0] "" Vector__XXX
  SG_ test_sig5_2 : 16|16@1- (1,0) [0|0] "" Vector__XXX
  SG_ test_sig5 : 0|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2347693089 car_state2: 1 TEST_NODE_2
+ SG_ car_state2 : 0|8@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 2550136829 daq_response_TEST_NODE_2: 8 TEST_NODE_2
  SG_ daq_response : 0|64@1+ (1,0) [0|0] "" Vector__XXX
@@ -243,10 +249,12 @@ CM_ SG_ 2483028351 test_sig5 "";
 CM_ BO_ 2348810751 "wheel speeds";
 CM_ SG_ 2348810751 right_speed "";
 CM_ SG_ 2348810751 left_speed "";
-CM_ BO_ 2147484882 "adc potentiometer readings";
-CM_ SG_ 2147484882 pot3 "";
-CM_ SG_ 2147484882 pot2 "";
-CM_ SG_ 2147484882 pot1 "";
+CM_ BO_ 2147488308 "adc potentiometer readings";
+CM_ SG_ 2147488308 pot3 "";
+CM_ SG_ 2147488308 pot2 "";
+CM_ SG_ 2147488308 pot1 "";
+CM_ BO_ 2347693088 "state of the car";
+CM_ SG_ 2347693088 car_state "";
 CM_ BO_ 2550136831 "daq response from node TEST_NODE";
 CM_ SG_ 2550136831 daq_response "";
 CM_ BO_ 2483028093 "test_msg desc";
@@ -261,6 +269,8 @@ CM_ BO_ 2483028349 "test_msg5 desc";
 CM_ SG_ 2483028349 test_sig5_3 "";
 CM_ SG_ 2483028349 test_sig5_2 "";
 CM_ SG_ 2483028349 test_sig5 "";
+CM_ BO_ 2347693089 "state of the car";
+CM_ SG_ 2347693089 car_state2 "";
 CM_ BO_ 2550136829 "daq response from node TEST_NODE_2";
 CM_ SG_ 2550136829 daq_response "";
 CM_ BO_ 2483032050 "daq command for node TEST_NODE";
@@ -270,7 +280,8 @@ CM_ SG_ 2483031922 daq_command "";
 
 
 
-
+VAL_ 2347693088 car_state 0 "ready2go" 1 "flipped" 2 "flying" 3 "lightspeed" ;
+VAL_ 2347693089 car_state2 0 "ready2go" 1 "flipped" 2 "flying" 3 "lightspeed" ;
 SIG_VALTYPE_ 2348810751 left_speed : 1;
 SIG_VALTYPE_ 2348810751 right_speed : 1;
 SIG_VALTYPE_ 2483028349 test_sig5_3 : 1;

--- a/common/daq/templates/can_parse_template.h
+++ b/common/daq/templates/can_parse_template.h
@@ -39,6 +39,9 @@
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
                     (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
 
+/* BEGIN AUTO CAN ENUMERATIONS */
+/* END AUTO CAN ENUMERATIONS */
+
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
 /* END AUTO MESSAGE STRUCTURE */

--- a/common/psched/psched.c
+++ b/common/psched/psched.c
@@ -255,7 +255,7 @@ void schedPause(void)
 static void memsetu(uint8_t* ptr, uint8_t val, size_t size)
 {
     // Locals
-    uint8_t i;
+    size_t i;
 
     for (i = 0; i < size; i++)
     {

--- a/source/dashboard/can/can_parse.h
+++ b/source/dashboard/can/can_parse.h
@@ -61,6 +61,9 @@
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
                     (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
 
+/* BEGIN AUTO CAN ENUMERATIONS */
+/* END AUTO CAN ENUMERATIONS */
+
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
 typedef union { __attribute__((packed))

--- a/source/driveline/can/can_parse.h
+++ b/source/driveline/can/can_parse.h
@@ -82,6 +82,9 @@
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
                     (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
 
+/* BEGIN AUTO CAN ENUMERATIONS */
+/* END AUTO CAN ENUMERATIONS */
+
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
 typedef union { __attribute__((packed))

--- a/source/l4_testing/can/can_parse.c
+++ b/source/l4_testing/can/can_parse.c
@@ -44,6 +44,9 @@ void canRxUpdate()
                 can_data.test_msg5_2.stale = 0;
                 can_data.test_msg5_2.last_rx = curr_tick;
                 break;
+            case ID_CAR_STATE2:
+                can_data.car_state2.car_state2 = msg_data_a->car_state2.car_state2;
+                break;
             case ID_DAQ_COMMAND_TEST_NODE:
                 can_data.daq_command_TEST_NODE.daq_command = msg_data_a->daq_command_TEST_NODE.daq_command;
                 daq_command_TEST_NODE_CALLBACK(&msg_header);
@@ -77,7 +80,9 @@ bool initCANFilter()
     /* BEGIN AUTO FILTER */
     CAN1->FA1R |= (1 << 0);    // configure bank 0
     CAN1->sFilterRegister[0].FR1 = (ID_TEST_MSG5_2 << 3) | 4;
-    CAN1->sFilterRegister[0].FR2 = (ID_DAQ_COMMAND_TEST_NODE << 3) | 4;
+    CAN1->sFilterRegister[0].FR2 = (ID_CAR_STATE2 << 3) | 4;
+    CAN1->FA1R |= (1 << 1);    // configure bank 1
+    CAN1->sFilterRegister[1].FR1 = (ID_DAQ_COMMAND_TEST_NODE << 3) | 4;
     /* END AUTO FILTER */
 
     CAN1->FMR  &= ~CAN_FMR_FINIT;             // Enable Filters (exit filter init mode)

--- a/source/l4_testing/can/can_parse.h
+++ b/source/l4_testing/can/can_parse.h
@@ -28,9 +28,11 @@
 #define ID_TEST_MSG4 0x1400013f
 #define ID_TEST_MSG5 0x1400017f
 #define ID_WHEEL_SPEEDS 0xc0001ff
-#define ID_ADC_VALUES 0x4d2
+#define ID_ADC_VALUES 0x1234
+#define ID_CAR_STATE 0xbeef420
 #define ID_DAQ_RESPONSE_TEST_NODE 0x17ffffff
 #define ID_TEST_MSG5_2 0x1400017d
+#define ID_CAR_STATE2 0xbeef421
 #define ID_DAQ_COMMAND_TEST_NODE 0x14000ff2
 /* END AUTO ID DEFS */
 
@@ -43,8 +45,10 @@
 #define DLC_TEST_MSG5 2
 #define DLC_WHEEL_SPEEDS 8
 #define DLC_ADC_VALUES 5
+#define DLC_CAR_STATE 1
 #define DLC_DAQ_RESPONSE_TEST_NODE 8
 #define DLC_TEST_MSG5_2 8
+#define DLC_CAR_STATE2 1
 #define DLC_DAQ_COMMAND_TEST_NODE 8
 /* END AUTO DLC DEFS */
 
@@ -103,6 +107,12 @@ typedef union {
         data_a->adc_values.pot3 = pot3_;\
         qSendToBack(&queue, &msg);\
     } while(0)
+#define SEND_CAR_STATE(queue, car_state_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_CAR_STATE, .DLC=DLC_CAR_STATE, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->car_state.car_state = car_state_;\
+        qSendToBack(&queue, &msg);\
+    } while(0)
 #define SEND_DAQ_RESPONSE_TEST_NODE(queue, daq_response_) do {\
         CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_DAQ_RESPONSE_TEST_NODE, .DLC=DLC_DAQ_RESPONSE_TEST_NODE, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
@@ -119,6 +129,23 @@ typedef union {
 
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
                     (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
+
+/* BEGIN AUTO CAN ENUMERATIONS */
+typedef enum {
+    CAR_STATE_READY2GO,
+    CAR_STATE_FLIPPED,
+    CAR_STATE_FLYING,
+    CAR_STATE_LIGHTSPEED,
+} car_state_t;
+
+typedef enum {
+    CAR_STATE2_READY2GO,
+    CAR_STATE2_FLIPPED,
+    CAR_STATE2_FLYING,
+    CAR_STATE2_LIGHTSPEED,
+} car_state2_t;
+
+/* END AUTO CAN ENUMERATIONS */
 
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
@@ -148,6 +175,9 @@ typedef union { __attribute__((packed))
         uint64_t pot3: 12;
     } adc_values;
     struct {
+        uint64_t car_state: 8;
+    } car_state;
+    struct {
         uint64_t daq_response: 64;
     } daq_response_TEST_NODE;
     struct {
@@ -155,6 +185,9 @@ typedef union { __attribute__((packed))
         uint64_t test_sig5_2: 16;
         uint64_t test_sig5_3: 32;
     } test_msg5_2;
+    struct {
+        uint64_t car_state2: 8;
+    } car_state2;
     struct {
         uint64_t daq_command: 64;
     } daq_command_TEST_NODE;
@@ -173,6 +206,9 @@ typedef struct {
         uint8_t stale;
         uint32_t last_rx;
     } test_msg5_2;
+    struct {
+        car_state2_t car_state2;
+    } car_state2;
     struct {
         uint64_t daq_command;
     } daq_command_TEST_NODE;

--- a/source/l4_testing/main.c
+++ b/source/l4_testing/main.c
@@ -252,6 +252,7 @@ void canSendTest()
     SEND_TEST_MSG3(q_tx_can, counter2);
     SEND_TEST_MSG4(q_tx_can, counter2);
     SEND_TEST_MSG5(q_tx_can, 0xFFF - counter2);
+    SEND_CAR_STATE(q_tx_can, CAR_STATE_FLIPPED);
 }
 
 void canTxUpdate()

--- a/source/main_module/can/can_parse.h
+++ b/source/main_module/can/can_parse.h
@@ -63,6 +63,9 @@
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
                     (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
 
+/* BEGIN AUTO CAN ENUMERATIONS */
+/* END AUTO CAN ENUMERATIONS */
+
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
 typedef union { __attribute__((packed))

--- a/source/precharge/can/can_parse.h
+++ b/source/precharge/can/can_parse.h
@@ -57,6 +57,9 @@
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
                     (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
 
+/* BEGIN AUTO CAN ENUMERATIONS */
+/* END AUTO CAN ENUMERATIONS */
+
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
 typedef union { __attribute__((packed))

--- a/source/torque_vector/can/can_parse.h
+++ b/source/torque_vector/can/can_parse.h
@@ -63,6 +63,9 @@
 #define CHECK_STALE(stale, curr, last, period) if(!stale && \
                     (curr - last) * RX_UPDATE_PERIOD > period * STALE_THRESH) stale = 1
 
+/* BEGIN AUTO CAN ENUMERATIONS */
+/* END AUTO CAN ENUMERATIONS */
+
 // Message Raw Structures
 /* BEGIN AUTO MESSAGE STRUCTURE */
 typedef union { __attribute__((packed))


### PR DESCRIPTION
Under a signal definition, you may optionally add "choices", a list of strings to be converted to an Enum. This will also be included in the dbc. I have verified the cangaroo is able to parse the choices correctly. This is great for showing system states. However, DAQ app currently just shows the value, its a WIP. 