### PR TITLE
Remove F4 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "firmware/common/STM32CubeL4"]
 	path = common/STM32CubeL4
 	url = https://github.com/STMicroelectronics/STM32CubeL4.git
-[submodule "common/STM32CubeF4"]
-	path = common/STM32CubeF4
-	url = https://github.com/STMicroelectronics/STM32CubeF4.git
 [submodule "common/eeprom"]
 	path = common/eeprom
 	url = https://github.com/PurdueElectricRacing/EEPROM.git


### PR DESCRIPTION
We don't use F4 at all, no need to pollute our CircleCI builds and use more internet infrastructure than needed to download it each time.