### PR TITLE
Fix core and stats

### DIFF
--- a/common/psched/psched.c
+++ b/common/psched/psched.c
@@ -1,11 +1,12 @@
 #include "psched.h"
 #include <stddef.h>
 
-static void checkPreflightSwap(void);
+static void checkPreflightEnd(void);
 static void schedLoop(void);
 static void schedBg(void);
+static void updateTime(cpu_time_t* time);
+static void calcTime(cpu_time_t* time, uint8_t count, int type);
 static void memsetu(uint8_t* ptr, uint8_t val, size_t size);
-static void calcStats(void);
 
 sched_t sched;
 
@@ -15,10 +16,17 @@ sched_t sched;
 //
 // @param: func: Pointer to function to run 
 // @param: task_time: Rate of task in ms
-void taskCreate(func_ptr_t func, uint16_t task_time)
+int taskCreate(func_ptr_t func, uint16_t task_time)
 {
-    sched.task_time[sched.task_count] = task_time;
-    sched.task_pointer[sched.task_count++] = func;
+    if (sched.fg_count != MAX_TASKS)
+    {
+        sched.task_time[sched.fg_count] = task_time;
+        sched.task_pointer[sched.fg_count++] = func;
+
+        return 0;
+    }
+
+    return -E_NO_FREE_TASK;
 }
 
 // @funcname: taskCreateBackground()
@@ -26,21 +34,16 @@ void taskCreate(func_ptr_t func, uint16_t task_time)
 // @brief: Adds background task to scheduler
 //
 // @param: func: Pointer to function to run
-void taskCreateBackground(func_ptr_t func)
+int taskCreateBackground(func_ptr_t func)
 {
-    sched.bg_pointer[sched.bg_count++] = func;
-}
+    if (sched.bg_count != MAX_TASKS)
+    {
+        sched.bg_pointer[sched.bg_count++] = func;
 
-// @funcname: setLoggingLevel()
-//
-// @brief: Sets level of CAN logging for task timing
-//
-// @param: level: 0 for no logging, 1 for critical errors only, 2 for everything
-void setLogging(uint8_t level, func_ptr_t handler)
-{
-    sched.llevel = level;
-    sched.exception_handler = handler;
-    sched.handler_set = 1;
+        return 0;
+    }
+
+    return -E_NO_FREE_TASK;
 }
 
 // @funcname: taskDelete()
@@ -55,11 +58,11 @@ void taskDelete(uint8_t type, uint8_t task)
     uint8_t i;
     func_ptr_t* fp;
 
-     if (type == TASK_FG)
+     if (type == TASK)
      {
          fp = sched.task_pointer;
         
-         for (i = task; i < sched.task_count; i++)
+         for (i = task; i < sched.fg_count; i++)
          {
              sched.task_time[i] = sched.task_time[i + 1];
          }
@@ -69,12 +72,12 @@ void taskDelete(uint8_t type, uint8_t task)
          fp = sched.bg_pointer;
      }
 
-     for (i = task; i < sched.task_count; i++)
+     for (i = task; i < sched.fg_count; i++)
      {
          fp[i] = fp[i + 1];
      }
 
-     --sched.task_count;
+     --sched.fg_count;
 }
 
 // @funcname: configureAnim()
@@ -114,186 +117,43 @@ void registerPreflightComplete(uint8_t status)
 void schedInit(uint32_t freq)
 {
     /*
-        Note: This system uses timer 2 and the watchdog peripheral
+        Note: This system uses timer 7 and the watchdog peripheral
         If you want/need to use this timer, it is on you to edit the configuration
         to use a different timer.
-        DO NOT ATTEMPT TO CONFIGURE THIS TIMER IN CUBE!
+        DO NOT ATTEMPT TO CONFIGURE THIS TIMER IN CUBE (or on your own)!
         The configuration for this timer is done manually, right here.
-        The watchdog will trigger a reset if all loops take longer than 3 ms to return
-
+        The watchdog will trigger a reset if all loops take longer than 10 ms to return
         Also, functions need to return to work properly. The scheduler works on a timer interrupt.
         If the functions called in the timer interrupt, you're going to have a stack overflow.
 
-        Frequencies are given in OS ticks.
+        Frequencies are given in OS ticks (1 ms)
     */
 
     // Configure timer 2
     // Targeting an interrupt every 1 ms
-    #ifndef PSCHED_USE_TIM7
-    RCC->APB1ENR1 |= RCC_APB1ENR1_TIM2EN;
-    #else
     RCC->APB1ENR1 |= RCC_APB1ENR1_TIM7EN;
-    #endif
-    P_TIM->PSC = (freq / 1000000) - 1;
-    P_TIM->ARR = 1000;
-    P_TIM->CR1 &= ~(TIM_CR1_DIR);
-    P_TIM->DIER |= TIM_DIER_UIE;
+    TIM7->PSC = (freq / 1000000) - 1;
+    TIM7->ARR = ARR_SET;
+    TIM7->CR1 &= ~(TIM_CR1_DIR);
+    TIM7->DIER |= TIM_DIER_UIE;
 
     // Default all values
     memsetu((uint8_t*) &sched, 0, sizeof(sched));
     sched.of = freq;
 }
 
-// @funcname: checkPreflightSwap()
-//
-// @brief: Checks if we're clear of preflight,
-//         and if we're able to swap to primary task pool
-static void checkPreflightSwap()
-{
-    int32_t new_time;
-
-    if (!sched.anim_min_time)
-    {
-        sched.anim_complete = 1;
-    }
-    else
-    {
-        --sched.anim_min_time;
-    }
-}
-
-// @funcname: schedLoop()
-//
-// @brief: Main loop that'll run each task
-static void schedLoop(void)
-{
-    // Locals
-    uint8_t i;
-
-    while (sched.running == 1)
-    {
-        // Prep iteration
-        sched.run_next = 0;
-        IWDG->KR = 0xAAAA;
-
-        // Store fg entry
-        sched.core.fg_stats.entry_time_cnt = P_TIM->CNT;
-        sched.core.fg_stats.entry_time_ticks = sched.os_ticks;
-
-        // Execute tasks
-        if (sched.preflight_required && (!sched.anim_complete || !sched.preflight_complete))
-        {
-            if (sched.os_ticks % sched.anim_time == 0)
-            {
-                sched.anim();
-            }
-            sched.preflight();
-            checkPreflightSwap();
-        }
-        else
-        {
-            for (i = 0; i < sched.task_count; i++)
-            {
-                if (sched.os_ticks % sched.task_time[i] == 0)
-                {
-                    (*sched.task_pointer[i])();
-                }
-                sched.fg_task_stats[i].entry_time_cnt = P_TIM->CNT;
-                sched.fg_task_stats[i].entry_time_ticks = sched.os_ticks;
-                (*sched.task_pointer[i])();
-                sched.fg_task_stats[i].exit_time_cnt = P_TIM->CNT;
-                sched.fg_task_stats[i].exit_time_ticks = sched.os_ticks;
-            }
-        }
-
-        // Store fg exit
-        sched.core.fg_stats.exit_time_cnt = P_TIM->CNT;
-        sched.core.fg_stats.exit_time_ticks = sched.os_ticks;
-
-        // Check if we missed timing requirements
-        if (sched.run_next == 1)
-        {
-            ++sched.skips;
-        }
-
-        // Store bg entry
-        sched.core.bg_stats.entry_time_cnt = P_TIM->CNT;
-        sched.core.bg_stats.entry_time_ticks = sched.os_ticks;
-
-        // Bg entry point
-        schedBg();
-
-        // Store bg exit
-        sched.core.bg_stats.entry_time_cnt = P_TIM->CNT;
-        sched.core.bg_stats.entry_time_ticks = sched.os_ticks;
-
-        // Calculate task runtimes
-        calcStats();
-    }
-}
-
-// @funcname: schedBg()
-//
-// @brief: Background loop running when nothing else is
-static void schedBg(void)
-{
-    // Locals
-    uint8_t i;
-
-    while (1)
-    {
-        // Check if we should break
-        if (sched.run_next == 1)
-        {
-            return;
-        }
-
-        // Execute background tasks
-        for (i = 0; i < sched.bg_count; i++)
-        {
-            (*sched.bg_pointer[i])();
-        }
-    }
-}
-
-// @funcname: waitMicros()
-//
-// @brief: Waits for set time in microseconds,
-//         but never for more than 100μs at a time
-//
-// @param: time: time to wait in μs
-void waitMicros(uint8_t time)
-{
-    if (time > 100) time = 100;
-
-    uint16_t entry_time = P_TIM->CNT; // ARR is 1k, so no cast issues
-    int16_t  exit_time = (int16_t) entry_time - time;
-
-    if (exit_time < 0)
-    {
-        exit_time += 1000;
-        while (P_TIM->CNT < entry_time);
-    }
-
-    while (P_TIM->CNT > exit_time);
-}
-
 // @funcname: schedStart()
 //
 // @brief: Starts tasks. Will never return
-void schedStart(void)
+void schedStart()
 {
-    P_TIM->CR1 |= TIM_CR1_CEN;
-    #ifndef PSCHED_USE_TIM7
-    NVIC->ISER[0] |= 1 << TIM2_IRQn;
-    #else
+    TIM7->CR1     |= TIM_CR1_CEN;
     NVIC->ISER[1] |= 1 << (TIM7_IRQn - 32);
-    #endif
-    IWDG->KR  =  0xCCCC;     
-    IWDG->KR  =  0x5555;
-    IWDG->PR  |= 2;
-    IWDG->RLR =  20;
-    sched.running = 1;
+    IWDG->KR      =  0xCCCC;     
+    IWDG->KR      =  0x5555;
+    IWDG->PR      |= 2;
+    IWDG->RLR     =  20;
+    sched.running =  1;
 
     while ((IWDG->SR & 0b111) != 0);
 
@@ -312,14 +172,193 @@ void schedStart(void)
 //         within 3ms, your MCU will reset
 void schedPause()
 {
-    P_TIM->CR1 &= ~TIM_CR1_CEN;
-    #ifndef PSCHED_USE_TIM7
-    NVIC->ISER[0] &= ~(1 << TIM2_IRQn);
-    #else
+    TIM7->CR1 &= ~TIM_CR1_CEN;
     NVIC->ISER[1] &= ~(1 << (TIM7_IRQn - 32));
-    #endif
     sched.running = 0;
     sched.run_next = 1;
+}
+
+// @funcname: waitMicros()
+//
+// @brief: Waits for set time in microseconds,
+//         but never for more than 100μs at a time
+//
+// @param: time: time to wait in μs
+//
+// @note: Think long and hard about the use of
+//        this function before you slap it everywhere
+void waitMicros(uint8_t time)
+{
+    if (time > 100) time = 100;
+
+    // ARR is 1k, so no cast issues
+    uint16_t entry_time = TIM7->CNT;
+    int16_t  exit_time = (int16_t) entry_time - time;
+
+    if (exit_time < 0)
+    {
+        exit_time += 1000;
+        while (TIM7->CNT < entry_time);
+    }
+
+    while (TIM7->CNT > exit_time);
+}
+
+// @funcname: checkPreflightSwap()
+//
+// @brief: Checks if we're clear of preflight,
+//         and if we're able to swap to primary task pool
+static void checkPreflightEnd()
+{
+    int32_t new_time;
+
+    if (!sched.anim_min_time)
+    {
+        sched.anim_complete = 1;
+    }
+    else
+    {
+        --sched.anim_min_time;
+    }
+}
+
+// @funcname: schedLoop()
+//
+// @brief: Main loop that'll run each task
+static void schedLoop()
+{
+    // Locals
+    uint8_t i;
+
+    while (sched.running == 1)
+    {
+        // Prep iteration
+        sched.run_next = 0;
+        IWDG->KR = 0xAAAA;
+
+        sched.fg_time.tick_entry = sched.os_ticks;
+        sched.fg_time.cnt_entry = TIM7->CNT;
+
+        // Execute tasks
+        if (sched.preflight_required && (!sched.anim_complete || !sched.preflight_complete))
+        {
+            if (sched.os_ticks % sched.anim_time == 0)
+            {
+                sched.anim();
+            }
+
+            sched.preflight();
+            checkPreflightEnd();
+        }
+        else
+        {
+            for (i = 0; i < sched.fg_count; i++)
+            {
+                if ((sched.os_ticks - sched.ind_fg_time[i].tick_entry) > sched.task_time[i])
+                {
+                    sched.ind_fg_time[i].tick_entry = sched.os_ticks;
+                    sched.ind_fg_time[i].cnt_entry = TIM7->CNT;
+                    (*sched.task_pointer[i])();
+                    sched.ind_fg_time[i].tick_exit = sched.os_ticks;
+                    sched.ind_fg_time[i].cnt_exit = TIM7->CNT;
+                }
+            }
+        }
+
+        sched.fg_time.tick_exit = sched.os_ticks;
+        sched.fg_time.cnt_exit = TIM7->CNT;
+
+        // Check if we missed timing requirements
+        if (sched.run_next == 1)
+        {
+            ++sched.skips;
+        }
+
+        schedBg();
+
+        calcTime(&sched.fg_time, 1, E_FG_MISS);
+        calcTime(&sched.bg_time, 1, E_BG_MISS);
+        calcTime(&sched.ind_fg_time, sched.fg_count, E_IND_FG_MISS);
+    }
+}
+
+// @funcname: schedBg()
+//
+// @brief: Background loop running when nothing else is
+static void schedBg()
+{
+    // Locals
+    uint8_t i;
+
+    sched.bg_time.tick_entry = sched.os_ticks;
+    sched.bg_time.cnt_entry = TIM7->CNT;
+
+    while (1)
+    {
+        // Check if we should break
+        if (sched.run_next == 1)
+        {
+            sched.bg_time.tick_exit = sched.os_ticks;
+            sched.bg_time.cnt_exit = TIM7->CNT;
+
+            return;
+        }
+
+        // Execute background tasks
+        for (i = 0; i < sched.bg_count; i++)
+        {
+            (*sched.bg_pointer[i])();
+        }
+    }
+}
+
+static void updateTime(cpu_time_t* time)
+{
+    uint32_t delta;
+
+    delta = time->cnt_exit - time->cnt_entry;
+    time->cpu_use = (((float) delta) / ARR_SET) * 100;
+
+    if (time->cpu_use > 100)
+    {
+        time->cpu_use = 100;
+    }
+
+    time->max_cpu_use = (time->cpu_use >  time->max_cpu_use) ? time->cpu_use : time->max_cpu_use;
+}
+
+static void calcTime(cpu_time_t* time, uint8_t count, int type)
+{
+    uint8_t error;
+    uint8_t e_cnt;
+    uint8_t i;
+
+    e_cnt = 0;
+
+    for (i = 0; i < count; i++)
+    {
+        error = (type != E_BG_MISS) ? time[i].tick_entry != time[i].tick_exit : time[i].tick_exit - time[i].tick_entry > 1;
+
+        if (error)
+        {
+            time[i].cpu_use = 100;
+            time[i].has_missed = 1;
+            ++e_cnt;
+        }
+        else
+        {
+            updateTime(&time[i]);
+        }
+    }
+
+    if (e_cnt)
+    {
+        sched.error |= 1U << type;
+    }
+    else
+    {
+        sched.error &= ~(1U << type);
+    }
 }
 
 // @funcname: memsetu
@@ -340,75 +379,12 @@ static void memsetu(uint8_t* ptr, uint8_t val, size_t size)
     }
 }
 
-// @funcname: statsHelper
-//
-// @brief: Runs actual calculation
-static void statsHelper(time_stats_t* stats)
-{
-    int16_t ttime;
-
-    if (stats->entry_time_ticks != stats->exit_time_ticks)
-    {
-        stats->cpu_use = 100;
-    }
-    else
-    {
-        ttime = stats->exit_time_cnt - stats->entry_time_cnt;
-
-        if (ttime < 0)
-        {
-            ttime += 1000;
-        }
-
-        stats->cpu_use = ((float) ttime) / 10;
-    }
-
-    if (!sched.handler_set)
-    {
-        return;
-    }
-
-    if (stats->cpu_use > CPU_HIGH && sched.llevel)
-    {
-        sched.exception_handler();
-    }
-    else if (stats->cpu_use > CPU_MID && sched.llevel == 2)
-    {
-        sched.exception_handler();
-    }
-}
-
-// @funcname: calcStats
-//
-// @brief: Calculates percent runtime of each task
-static void calcStats(void)
-{
-    uint8_t i;
-
-    statsHelper(&sched.core.fg_stats);
-    statsHelper(&sched.core.bg_stats);
-
-    for (i = 0; i < MAX_TASK; i++)
-    {
-        statsHelper(&sched.fg_task_stats[i]);
-    }
-}
-
 // @funcname: TIM7_IRQHandler()
 //
 // @brief: Timer 7 IRQ. Increments OS ticks and unblocks loop
-#ifndef PSCHED_USE_TIM7
-void TIM2_IRQHandler(void)
-#else
-void TIM7_IRQHandler(void)
-#endif
+void TIM7_IRQHandler()
 {
-	P_TIM->SR &= ~TIM_SR_UIF;
-
-    if (++sched.os_ticks == 30001)
-    {
-        sched.os_ticks = 0;
-    }
-
+	TIM7->SR &= ~TIM_SR_UIF;
+    ++sched.os_ticks;
     sched.run_next = 1;
 }

--- a/common/psched/psched.h
+++ b/common/psched/psched.h
@@ -14,80 +14,72 @@
     #error "Please define a MCU arch"
 #endif
 
-#ifndef PSCHED_USE_TIM7
-#define P_TIM TIM2
-#else
-#define P_TIM TIM7
-#endif
-
-#define MAX_TASK        15
-#define CPU_HIGH        90
-#define CPU_MID         75
-
 #define toMicros(time) ((uint32_t) time * 1000)
+
+#define ARR_SET         1000
+#define MAX_TASKS       32
+#define E_NO_FREE_TASK  1
+#define E_FG_MISS       2
+#define E_BG_MISS       3
+#define E_IND_FG_MISS   4
 
 // Structs, Enums, Types
 enum {
-    TASK_FG,
+    TASK,
     TASK_BG
 };
 
 typedef void (*func_ptr_t)(void);
 
 typedef struct {
-    uint32_t entry_time_ticks;              // Entry time in OS ticks
-    uint32_t exit_time_ticks;               // Exit time in OS ticks
-    uint16_t entry_time_cnt;                // Entry time in counter LSB
-    uint16_t exit_time_cnt;                 // Exit time in counter LSB
-    float    cpu_use;                       // %age of CPU use by this entity
-} time_stats_t;
+    uint32_t tick_entry;                    // OS tick count on entry
+    uint32_t tick_exit;                     // OS tick count on exit
+    uint32_t cnt_entry;                     // TIM7->CNT on entry
+    uint32_t cnt_exit;                      // TIM7->CNT on exit
 
-typedef struct {
-    time_stats_t fg_stats;                  // Foreground loop stats
-    time_stats_t bg_stats;                  // Background loop stats
-} cpu_t;
+    float    cpu_use;                       // Instantaneous CPU use
+    float    max_cpu_use;                   // Maximum CPU use (excluding timing misses)
+    uint8_t  has_missed;                    // Marks if a task has missed at some point
+} cpu_time_t;
 
 typedef struct
 {
-    uint8_t      llevel;                    // Logging level
-    uint8_t      handler_set;               // Flag for exception handler function
-    uint8_t    skips;                   // Number of loop misses. Execution time was skipped. Should always be 0
-    uint8_t    run_next;                // Triggers background to run next iteration
-    uint8_t    task_count;              // Number of tasks
-    uint8_t    bg_count;                // Number of background tasks
-    uint8_t    running;                 // Marks scheduler as running
-    uint8_t    preflight_required;      // Preflight in use
-    uint8_t    preflight_complete;      // Preflight complete registration
-    uint8_t    anim_complete;           // Preflight setup/inspection complete
-    uint16_t   anim_min_time;           // Minimum runtime of preflight animation
-    uint32_t   os_ticks;                // Current OS tick count
-    uint32_t   of;                      // MCU operating frequency
+    uint8_t    skips;                       // Number of loop misses. Execution time was skipped. Should always be 0
+    uint8_t    run_next;                    // Triggers background to run next iteration
+    uint8_t    fg_count;                    // Number of foreground tasks
+    uint8_t    bg_count;                    // Number of background tasks
+    uint8_t    running;                     // Marks scheduler as running
+    uint8_t    preflight_required;          // Preflight in use
+    uint8_t    preflight_complete;          // Preflight complete registration
+    uint8_t    anim_complete;               // Preflight setup/inspection complete
+    uint8_t    error;                       // Core error flags
+    uint16_t   anim_min_time;               // Minimum runtime of preflight animation
+    uint32_t   os_ticks;                    // Current OS tick count
+    uint32_t   of;                          // MCU operating frequency
 
-    uint16_t     task_time[MAX_TASK];       // Task interval in ms
-    func_ptr_t   task_pointer[MAX_TASK];    // Function pointers to tasks
-    func_ptr_t   bg_pointer[MAX_TASK];      // Function pointers to background tasks
-    func_ptr_t   exception_handler;         // Function pointer to exception handler
+    uint16_t   task_time[MAX_TASKS];        // Timings of registered tasks
+    uint16_t   anim_time;                   // Timing of animation
+    func_ptr_t task_pointer[MAX_TASKS];     // Function pointers to tasks
+    func_ptr_t bg_pointer[MAX_TASKS];       // Function pointers to background tasks
 
-    time_stats_t fg_task_stats[MAX_TASK];   // Foreground task stats
+    func_ptr_t anim;                        // Animation function
+    func_ptr_t preflight;                   // Preflight function
 
-    uint16_t   anim_time;               // Timing of animation
-    func_ptr_t anim;                    // Animation function
-    func_ptr_t preflight;               // Preflight function
-
-    cpu_t    core;
+    cpu_time_t fg_time;                     // Foreground time use
+    cpu_time_t bg_time;                     // Background time use
+    cpu_time_t ind_fg_time[MAX_TASKS];      // Individual foreground task time use
 } sched_t;
 
 extern sched_t sched;
 
 // Prototypes
-void taskCreate(func_ptr_t func, uint16_t task_time);
-void taskCreateBackground(func_ptr_t func);
-void setLogging(uint8_t level, func_ptr_t handler);
+int  taskCreate(func_ptr_t func, uint16_t task_time);
+int  taskCreateBackground(func_ptr_t func);
 void taskDelete(uint8_t type, uint8_t task);
 void configureAnim(func_ptr_t anim, func_ptr_t preflight, uint16_t anim_time, uint16_t anim_min_time);
 void registerPreflightComplete(uint8_t status);
 void schedInit(uint32_t freq);
-void schedStart(void);
-void schedPause(void);
+void schedStart();
+void schedPause();
 
 #endif


### PR DESCRIPTION
- Removed hard stop on os_ticks. Scheduling is now based on last entry time. Unsigned math with os_ticks should be viable again
- Set psched to permanently use timer 7. No more conflicts with wheelspeed
- Revamped stats. Individual tasks will now show max/instantaneous CPU use in % (excluding timing misses). Timing misses are also visible. It should be very easy to find out what is causing a watchdog reset now/where we can save some time
- Re-added/fixed animations. If no animation is desired, the typical workflow will work perfectly. If they're desired, the BMS project shows an example usage. Clocks and GPIO must be configured prior to the call to sched_start(). If your initialization task doesn't register completion, the animation will hang forever!
- Max task count is now 32
- Tested rollover functionality of os_ticks. The scheduler shouldn't hang on its own anymore. If heartbeat is getting a little odd, it's purely application code at this point
- Typical refactoring. Static functions are all at the bottom, and in a more logical order. checkPreflightSwap was renamed to make more sense. Stats were cleaned up quite a bit
- Added error codes. sched.error will now show all tasks realms that are causing timing misses