### PR TITLE
Zeroing out flow rate after specified time

### DIFF
--- a/source/pdu/flow_rate/flow_rate.c
+++ b/source/pdu/flow_rate/flow_rate.c
@@ -1,4 +1,5 @@
 #include "flow_rate.h"
+#include "common/psched/psched.h"
 
 extern uint32_t APB1ClockRateHz;
 extern uint32_t APB2ClockRateHz;

--- a/source/pdu/flow_rate/flow_rate.h
+++ b/source/pdu/flow_rate/flow_rate.h
@@ -5,6 +5,8 @@
 #include "stm32f407xx.h"
 #include "main.h"
 
+#define MAX_TIME_BETWEEN_CC_MS 15
+
 bool flowRateInit();
 uint32_t getFlowRate1();
 uint32_t getFlowRate2();


### PR DESCRIPTION
This has not been tested and I am currently now sure on the amount of time that is needed between capture compare events.

Please let me know of any changes or redesigns that are necessary