### PR TITLE
[READY] Reduce hex size

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -31,7 +31,7 @@ function(postbuild_target TARGET_NAME)
     )
 
     add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-        COMMAND arm-none-eabi-objcopy -S -O ihex --gap-fill 0 ${TARGET_NAME} ${COMPONENT_OUTPUT_DIR}/${OUTPUT_FILE_NAME}.hex
+        COMMAND arm-none-eabi-objcopy -S -O ihex ${TARGET_NAME} ${COMPONENT_OUTPUT_DIR}/${OUTPUT_FILE_NAME}.hex
         COMMENT "Generateing HEX file"
     )
 


### PR DESCRIPTION
6 months ago gap fill was added to post build hex copying. This caused some hex inflation - up to 1GB....
This needed to be removed