### PR TITLE
Post dashboard voltages periodically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Any PRs made to protected branches need to be approved by a specific group of people
 # who have knowledge about the entire codebase to avoid regressions in previously
 # established behavior.
-@reviewers
+@PurdueElectricRacing/reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Any PRs made to protected branches need to be approved by a specific group of people
+# who have knowledge about the entire codebase to avoid regressions in previously
+# established behavior.
+@reviewers

--- a/common/daq/can_config.json
+++ b/common/daq/can_config.json
@@ -691,16 +691,27 @@
                             "msg_pgn":0
                         },
                         {
-                            "msg_name":"dashboard_volts_temp",
+                            "msg_name":"dashboard_temp",
                             "msg_desc":"periodic dashboard MCU temp",
                             "signals":[
-                                {"sig_name": "mcu_temp", "type":"int16_t"},
-                                {"sig_name": "volts_5v", "type":"uint16_t"},
-                                {"sig_name": "volts_3v3", "type":"uint16_t"}
+                                {"sig_name": "mcu_temp", "type":"int16_t"}
                             ],
                             "msg_period":500,
                             "msg_hlp":4,
                             "msg_pgn":101
+                        },
+                        {
+                            "msg_name":"dashboard_voltage",
+                            "msg_desc":"periodic dashboard MCU voltages",
+                            "signals":[
+                                {"sig_name": "volts_3v3", "type":"uint16_t", "scale": 0.01, "unit": "V"},
+                                {"sig_name": "volts_5v", "type":"uint16_t", "scale": 0.01, "unit": "V"},
+                                {"sig_name": "volts_12v", "type":"uint16_t", "scale": 0.01, "unit": "V"},
+                                {"sig_name": "volts_24v", "type":"uint16_t", "scale": 0.01, "unit": "V"}
+                            ],
+                            "msg_period":1000,
+                            "msg_hlp":4,
+                            "msg_pgn":102
                         },
                         {
                             "msg_name":"dashboard_tv_parameters",

--- a/common/daq/per_dbc.dbc
+++ b/common/daq/per_dbc.dbc
@@ -350,10 +350,14 @@ BO_ 2214593093 filt_throttle_brake: 3 Dashboard
 BO_ 2214592517 start_button: 1 Dashboard
  SG_ start : 0|1@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 2415925573 dashboard_volts_temp: 6 Dashboard
- SG_ volts_3v3 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
- SG_ volts_5v : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+BO_ 2415925573 dashboard_temp: 2 Dashboard
  SG_ mcu_temp : 0|16@1- (1,0) [0|0] "" Vector__XXX
+
+BO_ 2415925637 dashboard_voltage: 8 Dashboard
+ SG_ volts_24v : 48|16@1+ (0.01,0) [0|0] "V" Vector__XXX
+ SG_ volts_12v : 32|16@1+ (0.01,0) [0|0] "V" Vector__XXX
+ SG_ volts_5v : 16|16@1+ (0.01,0) [0|0] "V" Vector__XXX
+ SG_ volts_3v3 : 0|16@1+ (0.01,0) [0|0] "V" Vector__XXX
 
 BO_ 2214596037 dashboard_tv_parameters: 7 Dashboard
  SG_ tv_p_val : 33|16@1+ (1,0) [0|0] "" Vector__XXX
@@ -900,9 +904,12 @@ CM_ SG_ 2214593093 throttle "";
 CM_ BO_ 2214592517 "Car start button pressed";
 CM_ SG_ 2214592517 start "";
 CM_ BO_ 2415925573 "periodic dashboard MCU temp";
-CM_ SG_ 2415925573 volts_3v3 "";
-CM_ SG_ 2415925573 volts_5v "";
 CM_ SG_ 2415925573 mcu_temp "";
+CM_ BO_ 2415925637 "periodic dashboard MCU voltages";
+CM_ SG_ 2415925637 volts_24v "";
+CM_ SG_ 2415925637 volts_12v "";
+CM_ SG_ 2415925637 volts_5v "";
+CM_ SG_ 2415925637 volts_3v3 "";
 CM_ BO_ 2214596037 "periodic dashboard tv parameters";
 CM_ SG_ 2214596037 tv_p_val "";
 CM_ SG_ 2214596037 tv_intensity_val "";

--- a/source/dashboard/can/can_parse.h
+++ b/source/dashboard/can/can_parse.h
@@ -35,7 +35,8 @@ typedef union {
 #define ID_COOLING_DRIVER_REQUEST 0xc0002c5
 #define ID_FILT_THROTTLE_BRAKE 0x4000245
 #define ID_START_BUTTON 0x4000005
-#define ID_DASHBOARD_VOLTS_TEMP 0x10001945
+#define ID_DASHBOARD_TEMP 0x10001945
+#define ID_DASHBOARD_VOLTAGE 0x10001985
 #define ID_DASHBOARD_TV_PARAMETERS 0x4000dc5
 #define ID_DASHBOARD_START_LOGGING 0x4000e05
 #define ID_DASH_CAN_STATS 0x10016305
@@ -75,7 +76,8 @@ typedef union {
 #define DLC_COOLING_DRIVER_REQUEST 5
 #define DLC_FILT_THROTTLE_BRAKE 3
 #define DLC_START_BUTTON 1
-#define DLC_DASHBOARD_VOLTS_TEMP 6
+#define DLC_DASHBOARD_TEMP 2
+#define DLC_DASHBOARD_VOLTAGE 8
 #define DLC_DASHBOARD_TV_PARAMETERS 7
 #define DLC_DASHBOARD_START_LOGGING 1
 #define DLC_DASH_CAN_STATS 4
@@ -156,12 +158,19 @@ typedef union {
         data_a->start_button.start = start_;\
         canTxSendToBack(&msg);\
     } while(0)
-#define SEND_DASHBOARD_VOLTS_TEMP(mcu_temp_, volts_5v_, volts_3v3_) do {\
-        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_DASHBOARD_VOLTS_TEMP, .DLC=DLC_DASHBOARD_VOLTS_TEMP, .IDE=1};\
+#define SEND_DASHBOARD_TEMP(mcu_temp_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_DASHBOARD_TEMP, .DLC=DLC_DASHBOARD_TEMP, .IDE=1};\
         CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
-        data_a->dashboard_volts_temp.mcu_temp = mcu_temp_;\
-        data_a->dashboard_volts_temp.volts_5v = volts_5v_;\
-        data_a->dashboard_volts_temp.volts_3v3 = volts_3v3_;\
+        data_a->dashboard_temp.mcu_temp = mcu_temp_;\
+        canTxSendToBack(&msg);\
+    } while(0)
+#define SEND_DASHBOARD_VOLTAGE(volts_3v3_, volts_5v_, volts_12v_, volts_24v_) do {\
+        CanMsgTypeDef_t msg = {.Bus=CAN1, .ExtId=ID_DASHBOARD_VOLTAGE, .DLC=DLC_DASHBOARD_VOLTAGE, .IDE=1};\
+        CanParsedData_t* data_a = (CanParsedData_t *) &msg.Data;\
+        data_a->dashboard_voltage.volts_3v3 = volts_3v3_;\
+        data_a->dashboard_voltage.volts_5v = volts_5v_;\
+        data_a->dashboard_voltage.volts_12v = volts_12v_;\
+        data_a->dashboard_voltage.volts_24v = volts_24v_;\
         canTxSendToBack(&msg);\
     } while(0)
 #define SEND_DASHBOARD_TV_PARAMETERS(tv_enabled_, tv_deadband_val_, tv_intensity_val_, tv_p_val_) do {\
@@ -276,9 +285,13 @@ typedef union {
     } start_button;
     struct {
         uint64_t mcu_temp: 16;
-        uint64_t volts_5v: 16;
+    } dashboard_temp;
+    struct {
         uint64_t volts_3v3: 16;
-    } dashboard_volts_temp;
+        uint64_t volts_5v: 16;
+        uint64_t volts_12v: 16;
+        uint64_t volts_24v: 16;
+    } dashboard_voltage;
     struct {
         uint64_t tv_enabled: 1;
         uint64_t tv_deadband_val: 16;

--- a/source/dashboard/main.c
+++ b/source/dashboard/main.c
@@ -214,6 +214,7 @@ int main (void){
     taskCreate(update_data_pages, 200);
     taskCreate(sendTVParameters, 4000);
     taskCreate(updateSDCDashboard, 500);
+    taskCreate(sendVoltageData, 1000);
     taskCreateBackground(usartTxUpdate);
     taskCreateBackground(canTxUpdate);
     taskCreateBackground(canRxUpdate);
@@ -631,6 +632,25 @@ void pollDashboardInput()
         selectItem();
         dashboard_input &= ~(1U << DASH_INPUT_SELECT_BUTTON);
     }
+}
+
+void sendVoltageData()
+{
+    /*
+    Vin = (Vout * (R1 + R2)) / R2
+    V3v3: R1 = 4.3k, R2 = 10k
+    V5v: R1 = 4.3k, R2 = 3.3k
+    V12v: R1 = 15.8k, R2 = 3.3k
+    V24v: R1 = 47k, R2 = 3.3k
+    Scale Vin by 100 to avoid losing precision
+    */
+
+    SEND_DASHBOARD_VOLTAGE(
+        (uint16_t)((((raw_adc_values.lv_3v3_sense * 3.3) / 4095) * (4.3 + 10.0) / 10.0) * 100), 
+        (uint16_t)((((raw_adc_values.lv_5v_sense * 3.3) / 4095) * (4.3 + 3.3) / 3.3) * 100), 
+        (uint16_t)((((raw_adc_values.lv_12v_sense * 3.3) / 4095) * (15.8 + 3.3) / 3.3) * 100), 
+        (uint16_t)((((raw_adc_values.lv_24_v_sense * 3.3) / 4095) * (47.0 + 3.3) / 3.3) * 100)
+    );
 }
 
 void HardFault_Handler()

--- a/source/dashboard/main.c
+++ b/source/dashboard/main.c
@@ -638,21 +638,16 @@ void pollDashboardInput()
 
 void sendVoltageData()
 {
-    /*
-    Vin = (Vout * (R1 + R2)) / R2
-    V3v3: R1 = 4.3k, R2 = 10k
-    V5v: R1 = 4.3k, R2 = 3.3k
-    V12v: R1 = 15.8k, R2 = 3.3k
-    V24v: R1 = 47k, R2 = 3.3k
-    Scale Vin by 100 to avoid losing precision
-    */
+    float adc_to_voltage = ADC_REF_VOLTAGE / ADC_MAX_VALUE;
 
-    SEND_DASHBOARD_VOLTAGE(
-        (uint16_t)((((raw_adc_values.lv_3v3_sense * 3.3) / 4095) * (4.3 + 10.0) / 10.0) * 100), 
-        (uint16_t)((((raw_adc_values.lv_5v_sense * 3.3) / 4095) * (4.3 + 3.3) / 3.3) * 100), 
-        (uint16_t)((((raw_adc_values.lv_12v_sense * 3.3) / 4095) * (15.8 + 3.3) / 3.3) * 100), 
-        (uint16_t)((((raw_adc_values.lv_24_v_sense * 3.3) / 4095) * (47.0 + 3.3) / 3.3) * 100)
-    );
+    // Vin = Vout * (R1 + R2) / R2
+    u_int16_t vin_3v3 = (uint16_t)(raw_adc_values.lv_3v3_sense * adc_to_voltage * (V_3V3_RES_R1 + V_3V3_RES_R2) / V_3V3_RES_R2);
+    u_int16_t vin_5v = (uint16_t)(raw_adc_values.lv_5v_sense * adc_to_voltage * (V_5V_RES_R1 + V_5V_RES_R2) / V_5V_RES_R2);
+    u_int16_t vin_12v = (uint16_t)(raw_adc_values.lv_12v_sense * adc_to_voltage * (V_12V_RES_R1 + V_12V_RES_R2) / V_12V_RES_R2);
+    u_int16_t vin_24v = (uint16_t)(raw_adc_values.lv_24_v_sense * adc_to_voltage * (V_24V_RES_R1 + V_24V_RES_R2) / V_24V_RES_R2);
+
+    // Scale calculations by 100 to avoid losing precision
+    SEND_DASHBOARD_VOLTAGE(vin_3v3 * 100, vin_5v * 100, vin_12v * 100, vin_24v * 100);
 }
 
 void HardFault_Handler()

--- a/source/dashboard/main.c
+++ b/source/dashboard/main.c
@@ -162,6 +162,8 @@ void sendBrakeStatus();
 void interpretLoadSensor(void);
 void send_shockpots();
 float voltToForce(uint16_t load_read);
+void sendVoltageData();
+
 // Communication queues
 q_handle_t q_tx_usart;
 

--- a/source/dashboard/main.h
+++ b/source/dashboard/main.h
@@ -180,6 +180,18 @@ typedef enum
 #define LV_24_V_FAULT_Pin           (8)
 #define LV_5V_SCALE                 (0.413F)
 
+// Voltage Divider Resistors
+#define V_3V3_RES_R1   (4.3F)
+#define V_3V3_RES_R2   (10.0F)
+#define V_5V_RES_R1    (4.3F)
+#define V_5V_RES_R2    (3.3F)
+#define V_12V_RES_R1   (15.8F)
+#define V_12V_RES_R2   (3.3F)
+#define V_24V_RES_R1   (47.0F)
+#define V_24V_RES_R2   (3.3F)
+#define ADC_MAX_VALUE  (4095)
+#define ADC_REF_VOLTAGE (3.3F)
+
 void canTxSendToBack(CanMsgTypeDef_t *msg);
 
 #endif


### PR DESCRIPTION
This feature posts the dashboard 3v3, 5v, 12v, and 24v rails as onto the CAN bus once every second.

- Awaiting testing
- The 3v3 and 5v rails are posting higher than expected voltages. 
  - This may(?) be caused by a different resistor on the car than specified in the Altium design.

![image](https://github.com/user-attachments/assets/04dc7c8f-b402-4c35-8338-7965eb490cc6)
