### PR TITLE
This should fix the mac issue but will not suppress linker warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Before you can compile software for PER car, here are some steps you need to tak
 6. Install [arm-none-eabi-gcc](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads): Compiler specific to ARM based targets.
    - [Windows](https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07win32/gcc-arm-none-eabi-10.3-2021.07-win32.exe)
       - Note: You must manually add this to your path. To do so, open the start menu and select "edit the system environment variables". From here, copy the full file path of your arm-none-eabi-gcc executable into the PATH environment variable (C:\Program Files (x86)\GNU Arm Embedded Toolchain\10 2021.07\bin). Your filepath may not look exactly the same, but it should look similar to this.
-   - Mac: Install the required compiler using [homebrew](https://brew.sh/): `brew install arm-none-eabi-gcc`
+   <!-- - Mac: Install the required compiler using [homebrew](https://brew.sh/): `brew install arm-none-eabi-gcc` -->
+   - Mac: Install the required compiler using [homebrew](https://brew.sh/): `brew install gcc-arm-embedded`
    - Linux - Find it yourself
 7. Install [OpenOCD v0.11.0-3](https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.11.0-3/): Open Source On-Chip Debugger used to help GDB debug your code on a STM32 processor.
    - It is extremely important that you install this version of openocd or else you might run into issues with debugging

--- a/source/f7_testing/main.c
+++ b/source/f7_testing/main.c
@@ -29,10 +29,10 @@ int main()
     {
         HardFault_Handler();
     }
-    if(!PHAL_initGPIO(gpio_config, sizeof(gpio_config)/sizeof(GPIOInitConfig_t)))
-    {
-        HardFault_Handler();
-    }
+    // if(!PHAL_initGPIO(gpio_config, sizeof(gpio_config)/sizeof(GPIOInitConfig_t)))
+    // {
+    //     HardFault_Handler();
+    // }
         /* Task Creation */
     schedInit(APB1ClockRateHz);
         /* Schedule Periodic tasks here */

--- a/source/torque_vector/gps/gps.c
+++ b/source/torque_vector/gps/gps.c
@@ -30,7 +30,7 @@ double checkVelN;
 double checkVelN2;
 signed long prev_iTOW;
 uint16_t counter;
-u_int16_t diff;
+uint16_t diff;
 // Nav Message
 GPS_Handle_t gps_handle = {.raw_message = {0},
                            .g_speed = 0,


### PR DESCRIPTION
This will fix the issues, but not suppress linker warnings.

I have a few leads but since I am not getting the warnings myself, I don't want to blindly throw in a "fix" without seeing if it will fix the problem or break something else. https://stackoverflow.com/questions/73742774/gcc-arm-none-eabi-11-3-is-not-implemented-and-will-always-fail

@AdityaAsGithub You should I should cherry pick this commit and put it onto onboarding as well and create a separate PR, correct?