### PR TITLE
Fixing missing arg in function declaration (build with GCC 15)

### DIFF
--- a/source/main_module/main.c
+++ b/source/main_module/main.c
@@ -162,7 +162,7 @@ void send_fault(uint16_t, bool);
 extern void HardFault_Handler();
 void interpretLoadSensor(void);
 float voltToForce(uint16_t load_read);
-void can2Relaycan1();
+void can2Relaycan1(CAN_TypeDef *can_h);
 void calibrate_lws(void);
 
 int main(void)


### PR DESCRIPTION
*Why it errors*: In older versions, function declarations that look like `return_type fn_name()` mean that when  `fn_name()` is later defined, it may take any number of arguments. However, in newer versions it is equivalent to `return_type fn_name(void)`, meaning it must take exactly 0 arguments.

*In general*: fixes the typo :shrug: 