### PR TITLE
ABOX telemetry

### DIFF
--- a/common/can_library/configs/external_nodes/DAQ_APP.json
+++ b/common/can_library/configs/external_nodes/DAQ_APP.json
@@ -12,15 +12,15 @@
                     "type": "bool"
                 },
                 {
-                    "sig_name": "charge_voltage",
-                    "sig_desc": "Requested charge voltage in decivolts",
+                    "sig_name": "charge_volts",
+                    "sig_desc": "Requested charge voltage in Volts",
                     "type": "uint16_t",
                     "unit": "V",
                     "scale": 0.1
                 },
                 {
                     "sig_name": "charge_current",
-                    "sig_desc": "Requested charge current in deciamps",
+                    "sig_desc": "Requested charge current in Amps",
                     "type": "uint16_t",
                     "unit": "A",
                     "scale": 0.1

--- a/common/can_library/configs/nodes/A_BOX.json
+++ b/common/can_library/configs/nodes/A_BOX.json
@@ -34,15 +34,51 @@
                     "msg_period": 10
                 },
                 {
+                    "msg_name": "pack_voltage_temp_stats",
+                    "msg_desc": "Pack min/min max voltage and min/max temperature",
+                    "signals": [
+                        {
+                            "sig_name": "min_cell_voltage",
+                            "sig_desc": "Minimum cell voltage in the pack",
+                            "type": "uint16_t",
+                            "unit": "V",
+                            "scale": 0.005
+                        },
+                        {
+                            "sig_name": "max_cell_voltage",
+                            "sig_desc": "Maximum cell voltage in the pack",
+                            "type": "uint16_t",
+                            "unit": "V",
+                            "scale": 0.005
+                        },
+                        {
+                            "sig_name": "min_therm_temp",
+                            "sig_desc": "Minimum cell temperature in the pack",
+                            "type": "int16_t",
+                            "unit": "C",
+                            "scale": 0.01
+                        },
+                        {
+                            "sig_name": "max_therm_temp",
+                            "sig_desc": "Maximum cell temperature in the pack",
+                            "type": "int16_t",
+                            "unit": "C",
+                            "scale": 0.01
+                        }
+                    ],
+                    "msg_priority": 5,
+                    "msg_period": 200
+                },
+                {
                     "msg_name": "module_voltage_stats",
-                    "msg_desc": "Rotating module voltage statistics",
+                    "msg_desc": "Rotating module voltage statistics (min, max, sum)",
                     "signals": [
                         {
                             "sig_name": "module_index",
                             "sig_desc": "Module index in the daisy chain",
                             "type": "uint8_t",
                             "unit": "idx",
-                            "length": 8
+                            "length": 3
                         },
                         {
                             "sig_name": "min_voltage",
@@ -67,18 +103,25 @@
                         }
                     ],
                     "msg_priority": 4,
-                    "msg_period": 250
+                    "msg_period": 120
                 },
                 {
                     "msg_name": "module_temp_balance_stats",
-                    "msg_desc": "Rotating module temperature and balancing statistics",
+                    "msg_desc": "Rotating module temperature (min/max) and balancing statistics",
                     "signals": [
                         {
                             "sig_name": "module_index",
                             "sig_desc": "Module index in the daisy chain",
                             "type": "uint8_t",
                             "unit": "idx",
-                            "length": 8
+                            "length": 3
+                        },
+                        {
+                            "sig_name": "min_temp",
+                            "sig_desc": "Minimum thermistor temperature in the module",
+                            "type": "int16_t",
+                            "unit": "C",
+                            "scale": 0.01
                         },
                         {
                             "sig_name": "max_temp",
@@ -95,7 +138,7 @@
                         }
                     ],
                     "msg_priority": 4,
-                    "msg_period": 250
+                    "msg_period": 120
                 },
                 {
                     "msg_name": "module_sample",
@@ -130,7 +173,7 @@
                         }
                     ],
                     "msg_priority": 4,
-                    "msg_period": 40
+                    "msg_period": 25
                 },
                 {
                     "msg_name": "abox_version",

--- a/common/can_library/configs/nodes/A_BOX.json
+++ b/common/can_library/configs/nodes/A_BOX.json
@@ -5,7 +5,7 @@
             "peripheral": "FDCAN1",
             "tx": [
                 {
-                    "msg_name": "pack_stats",
+                    "msg_name": "pack_core_stats",
                     "msg_desc": "Pack voltage, current, and temperature",
                     "signals": [
                         {

--- a/common/can_library/configs/nodes/A_BOX.json
+++ b/common/can_library/configs/nodes/A_BOX.json
@@ -120,7 +120,7 @@
             ],
             "rx": [
                 {
-                    "msg_name": "elcon_status"
+                    "msg_name": "elcon_charger_status"
                 },
                 {
                     "msg_name": "charge_request"
@@ -194,6 +194,16 @@
             "time_to_latch": 10000,
             "time_to_unlatch": 10000,
             "lcd_message": "Pack Full"
+        },
+        {
+            "fault_name": "DAQAPP_STALE",
+            "max": 1,
+            "min": 0,
+            "priority": "warning",
+            "time_to_latch": 5000,
+            "time_to_unlatch": 5000,
+            "lcd_message": "DAQ App Stale"
         }
+
     ]
 }

--- a/common/can_library/configs/nodes/A_BOX.json
+++ b/common/can_library/configs/nodes/A_BOX.json
@@ -34,12 +34,112 @@
                     "msg_period": 10
                 },
                 {
+                    "msg_name": "module_voltage_stats",
+                    "msg_desc": "Rotating module voltage statistics",
+                    "signals": [
+                        {
+                            "sig_name": "module_index",
+                            "sig_desc": "Module index in the daisy chain",
+                            "type": "uint8_t",
+                            "unit": "idx",
+                            "length": 8
+                        },
+                        {
+                            "sig_name": "min_voltage",
+                            "sig_desc": "Minimum cell voltage in the module",
+                            "type": "uint16_t",
+                            "unit": "V",
+                            "scale": 0.01
+                        },
+                        {
+                            "sig_name": "max_voltage",
+                            "sig_desc": "Maximum cell voltage in the module",
+                            "type": "uint16_t",
+                            "unit": "V",
+                            "scale": 0.01
+                        },
+                        {
+                            "sig_name": "sum_voltage",
+                            "sig_desc": "Sum of cell voltages in the module",
+                            "type": "uint16_t",
+                            "unit": "V",
+                            "scale": 0.01
+                        }
+                    ],
+                    "msg_priority": 4,
+                    "msg_period": 250
+                },
+                {
+                    "msg_name": "module_temp_balance_stats",
+                    "msg_desc": "Rotating module temperature and balancing statistics",
+                    "signals": [
+                        {
+                            "sig_name": "module_index",
+                            "sig_desc": "Module index in the daisy chain",
+                            "type": "uint8_t",
+                            "unit": "idx",
+                            "length": 8
+                        },
+                        {
+                            "sig_name": "max_temp",
+                            "sig_desc": "Maximum thermistor temperature in the module",
+                            "type": "int16_t",
+                            "unit": "C",
+                            "scale": 0.1
+                        },
+                        {
+                            "sig_name": "balancing_mask",
+                            "sig_desc": "Bitmask of cells currently enabled for balancing",
+                            "type": "uint16_t",
+                            "length": 16
+                        }
+                    ],
+                    "msg_priority": 4,
+                    "msg_period": 250
+                },
+                {
+                    "msg_name": "module_sample",
+                    "msg_desc": "Rotating individual module cell voltage or thermistor sample",
+                    "signals": [
+                        {
+                            "sig_name": "module_index",
+                            "sig_desc": "Module index in the daisy chain",
+                            "type": "uint8_t",
+                            "unit": "idx",
+                            "length": 8
+                        },
+                        {
+                            "sig_name": "sample_index",
+                            "sig_desc": "Cell or thermistor index within the module",
+                            "type": "uint8_t",
+                            "unit": "idx",
+                            "length": 8
+                        },
+                        {
+                            "sig_name": "is_temp",
+                            "sig_desc": "True when sample_value is a thermistor temperature, false for a cell voltage",
+                            "unit": "bool",
+                            "type": "bool"
+                        },
+                        {
+                            "sig_name": "sample_value",
+                            "sig_desc": "Sample reading in volts or Celsius depending on is_temp",
+                            "type": "int16_t",
+                            "unit": "V or C",
+                            "scale": 0.01
+                        }
+                    ],
+                    "msg_priority": 4,
+                    "msg_period": 40
+                },
+                {
                     "msg_name": "abox_version",
                     "msg_desc": "ABox version",
                     "signals": [
                         {
                             "sig_name": "git_hash",
                             "type": "uint32_t",
+                            "unit": "hash",
                             "sig_desc": "int representation of git short hash"
                         }
                     ],

--- a/common/can_library/configs/nodes/A_BOX.json
+++ b/common/can_library/configs/nodes/A_BOX.json
@@ -120,7 +120,7 @@
             ],
             "rx": [
                 {
-                    "msg_name": "elcon_charger_status"
+                    "msg_name": "elcon_status"
                 },
                 {
                     "msg_name": "charge_request"

--- a/common/can_library/configs/nodes/A_BOX.json
+++ b/common/can_library/configs/nodes/A_BOX.json
@@ -27,7 +27,7 @@
                             "sig_desc": "Average cell temperature in the pack",
                             "type": "int16_t",
                             "unit": "C",
-                            "scale": 1
+                            "scale": 0.01
                         }
                     ],
                     "msg_priority": 5,
@@ -49,21 +49,21 @@
                             "sig_desc": "Minimum cell voltage in the module",
                             "type": "uint16_t",
                             "unit": "V",
-                            "scale": 0.01
+                            "scale": 0.005
                         },
                         {
                             "sig_name": "max_voltage",
                             "sig_desc": "Maximum cell voltage in the module",
                             "type": "uint16_t",
                             "unit": "V",
-                            "scale": 0.01
+                            "scale": 0.005
                         },
                         {
                             "sig_name": "sum_voltage",
                             "sig_desc": "Sum of cell voltages in the module",
                             "type": "uint16_t",
                             "unit": "V",
-                            "scale": 0.01
+                            "scale": 0.005
                         }
                     ],
                     "msg_priority": 4,
@@ -85,7 +85,7 @@
                             "sig_desc": "Maximum thermistor temperature in the module",
                             "type": "int16_t",
                             "unit": "C",
-                            "scale": 0.1
+                            "scale": 0.01
                         },
                         {
                             "sig_name": "balancing_mask",
@@ -126,7 +126,7 @@
                             "sig_desc": "Sample reading in volts or Celsius depending on is_temp",
                             "type": "int16_t",
                             "unit": "V or C",
-                            "scale": 0.01
+                            "scale": 0.005
                         }
                     ],
                     "msg_priority": 4,

--- a/common/can_library/configs/nodes/A_BOX.json
+++ b/common/can_library/configs/nodes/A_BOX.json
@@ -194,16 +194,6 @@
             "time_to_latch": 10000,
             "time_to_unlatch": 10000,
             "lcd_message": "Pack Full"
-        },
-        {
-            "fault_name": "DAQAPP_STALE",
-            "max": 1,
-            "min": 0,
-            "priority": "warning",
-            "time_to_latch": 5000,
-            "time_to_unlatch": 5000,
-            "lcd_message": "DAQ App Stale"
         }
-
     ]
 }

--- a/common/can_library/configs/nodes/DASHBOARD.json
+++ b/common/can_library/configs/nodes/DASHBOARD.json
@@ -59,7 +59,7 @@
                     "msg_name": "main_hb"
                 },
                 {
-                    "msg_name": "pack_stats"
+                    "msg_name": "pack_core_stats"
                 },
                 {
                     "msg_name": "wheel_speeds"

--- a/source/a_box/adbms/adbms6380.c
+++ b/source/a_box/adbms/adbms6380.c
@@ -159,6 +159,9 @@ adbms6380_read_result_t adbms6380_read(SPI_InitConfig_t *spi,
                                        const uint8_t cmd_buffer[ADBMS6380_COMMAND_PKT_SIZE],
                                        uint8_t *rx_buffer,
                                        size_t rx_length_per_module) {
+    // Clear buffer before reading
+    memset(rx_buffer, 0, module_count * rx_length_per_module);
+                                        
     // Send command and get response
     adbms6380_set_cs_low(spi);
     // First send command. Command is passed to all modules in the daisy chain.

--- a/source/a_box/charging.c
+++ b/source/a_box/charging.c
@@ -61,10 +61,6 @@ static inline void update_charge_request() {
     charge_enable = true;
 }
 
-static inline void report_charging_telemetry() {
-    // todo
-}
-
 void charging_fsm_periodic() {
     // set default states
     current_state = next_state;

--- a/source/a_box/charging.c
+++ b/source/a_box/charging.c
@@ -61,6 +61,10 @@ static inline void update_charge_request() {
     charge_enable = true;
 }
 
+static inline void report_charging_telemetry() {
+    // todo
+}
+
 void charging_fsm_periodic() {
     // set default states
     current_state = next_state;

--- a/source/a_box/charging.c
+++ b/source/a_box/charging.c
@@ -46,10 +46,10 @@ static inline void update_charge_request() {
     }
 
     // cap the charge request to max values
-    if (can_data.charge_request.charge_voltage > MAX_PACK_CHARGING_DECIVOLTS) {
+    if (can_data.charge_request.charge_volts > MAX_PACK_CHARGING_DECIVOLTS) {
         charge_request_decivolts = MAX_PACK_CHARGING_DECIVOLTS;
     } else {
-        charge_request_decivolts = can_data.charge_request.charge_voltage;
+        charge_request_decivolts = can_data.charge_request.charge_volts;
     }
 
     // cap the charge request to max values

--- a/source/a_box/charging.c
+++ b/source/a_box/charging.c
@@ -2,6 +2,7 @@
 #include "common/can_library/faults_common.h"
 #include "common/can_library/generated/can_types.h"
 #include "common/can_library/generated/A_BOX.h"
+#include "telem.h"
 
 static constexpr uint16_t MAX_PACK_CHARGING_DECIVOLTS = 540 * 10;
 static constexpr uint16_t MAX_PACK_CHARGING_DECIAMPS = 20 * 10;

--- a/source/a_box/main.c
+++ b/source/a_box/main.c
@@ -117,7 +117,7 @@ DEFINE_TASK(CAN_tx_update, 2, osPriorityNormal, STACK_2048);
 DEFINE_TASK(check_faults, 10, osPriorityNormal, STACK_512);
 DEFINE_TASK(charging_fsm_periodic, ELCON_COMMAND_PERIOD_MS, osPriorityNormal, STACK_512);
 DEFINE_TASK(fault_library_periodic, A_BOX_FAULT_SYNC_PERIOD_MS, osPriorityNormal, STACK_1024);
-DEFINE_TASK(report_telemetry, TELEM_REPORT_PERIOD_MS, osPriorityLow, STACK_512);
+DEFINE_TASK(report_telemetry, PACK_CORE_STATS_PERIOD_MS, osPriorityLow, STACK_512);
 DEFINE_HEARTBEAT_TASK(nullptr);
 
 int main(void) {

--- a/source/a_box/main.c
+++ b/source/a_box/main.c
@@ -110,9 +110,6 @@ static constexpr uint32_t REPORT_TELEMETRY_PERIOD_MS         = 8;
 static constexpr uint32_t PACK_STATS_SEND_PERIOD_MS          = 200;
 static constexpr uint32_t MODULE_STATS_SEND_PERIOD_MS        = 125;
 static constexpr uint32_t INDIVIDUAL_SAMPLE_SEND_PERIOD_MS   = 48;
-static constexpr float MODULE_VOLTAGE_SCALE                  = 100.0f;
-static constexpr float MODULE_TEMP_SCALE                     = 10.0f;
-static constexpr float MODULE_SAMPLE_SCALE                   = 100.0f;
 
 extern void HardFault_Handler(void);
 void bms_task(void);
@@ -120,17 +117,6 @@ void check_faults(void);
 void report_telemetry(void);
 void charging_fsm_periodic(void);
 
-static uint16_t scale_voltage(float voltage) {
-    return (uint16_t)(voltage * MODULE_VOLTAGE_SCALE);
-}
-
-static int16_t scale_temp(float temp_c) {
-    return (int16_t)(temp_c * MODULE_TEMP_SCALE);
-}
-
-static int16_t scale_sample(float sample_value) {
-    return (int16_t)(sample_value * MODULE_SAMPLE_SCALE);
-}
 
 static uint16_t balance_mask_from_module(size_t module_idx) {
     uint16_t balance_mask = 0;
@@ -146,14 +132,14 @@ static uint16_t balance_mask_from_module(size_t module_idx) {
 
 static void send_module_voltage_stats(size_t module_idx) {
     CAN_SEND_module_voltage_stats((uint8_t)module_idx,
-                                  scale_voltage(g_bms.modules[module_idx].min_voltage),
-                                  scale_voltage(g_bms.modules[module_idx].max_voltage),
-                                  scale_voltage(g_bms.modules[module_idx].sum_voltage));
+                                  (uint16_t)(g_bms.modules[module_idx].min_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_MIN_VOLTAGE),
+                                  (uint16_t)(g_bms.modules[module_idx].max_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_MAX_VOLTAGE),
+                                  (uint16_t)(g_bms.modules[module_idx].sum_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_SUM_VOLTAGE));
 }
 
 static void send_module_temp_balance_stats(size_t module_idx) {
     CAN_SEND_module_temp_balance_stats((uint8_t)module_idx,
-                                       scale_temp(g_bms.modules[module_idx].max_therm_temp),
+                                       (int16_t)(g_bms.modules[module_idx].max_therm_temp * PACK_COEFF_MODULE_TEMP_BALANCE_STATS_MAX_TEMP),
                                        balance_mask_from_module(module_idx));
 }
 
@@ -162,14 +148,14 @@ static void send_individual_module_sample(size_t module_idx, bool is_temp, size_
         CAN_SEND_module_sample((uint8_t)module_idx,
                                (uint8_t)sample_idx,
                                true,
-                               scale_sample(g_bms.modules[module_idx].therms_temps[sample_idx]));
+                               (int16_t)(g_bms.modules[module_idx].therms_temps[sample_idx] * PACK_COEFF_MODULE_SAMPLE_SAMPLE_VALUE));
         return;
     }
 
     CAN_SEND_module_sample((uint8_t)module_idx,
                            (uint8_t)sample_idx,
                            false,
-                           scale_sample(g_bms.modules[module_idx].cell_voltages[sample_idx]));
+                           (int16_t)(g_bms.modules[module_idx].cell_voltages[sample_idx] * PACK_COEFF_MODULE_SAMPLE_SAMPLE_VALUE));
 }
 
 // Thread Defines
@@ -273,9 +259,10 @@ void report_telemetry() {
 
     uint16_t pack_voltage = (uint16_t)(g_bms.sum_voltage * PACK_COEFF_PACK_STATS_PACK_VOLTAGE);
     int16_t pack_current = isense_to_current(isense_raw);
+    int16_t avg_temp = (int16_t)(g_bms.avg_therm_temp * PACK_COEFF_PACK_STATS_AVG_TEMP);
 
     while (now >= next_pack_stats_ms) {
-        CAN_SEND_pack_stats(pack_voltage, pack_current, g_bms.avg_therm_temp);
+        CAN_SEND_pack_stats(pack_voltage, pack_current, avg_temp);
         next_pack_stats_ms += PACK_STATS_SEND_PERIOD_MS;
     }
 

--- a/source/a_box/main.c
+++ b/source/a_box/main.c
@@ -106,12 +106,71 @@ uint8_t g_bms_tx_buf[ADBMS_SPI_TX_BUFFER_SIZE] = {0};
 
 static constexpr float MIN_V_FOR_BALANCE     = 3.0f;
 static constexpr float MIN_DELTA_FOR_BALANCE = 0.1f;
+static constexpr uint32_t REPORT_TELEMETRY_PERIOD_MS         = 8;
+static constexpr uint32_t PACK_STATS_SEND_PERIOD_MS          = 200;
+static constexpr uint32_t MODULE_STATS_SEND_PERIOD_MS        = 125;
+static constexpr uint32_t INDIVIDUAL_SAMPLE_SEND_PERIOD_MS   = 48;
+static constexpr float MODULE_VOLTAGE_SCALE                  = 100.0f;
+static constexpr float MODULE_TEMP_SCALE                     = 10.0f;
+static constexpr float MODULE_SAMPLE_SCALE                   = 100.0f;
 
 extern void HardFault_Handler(void);
 void bms_task(void);
 void check_faults(void);
 void report_telemetry(void);
 void charging_fsm_periodic(void);
+
+static uint16_t scale_voltage(float voltage) {
+    return (uint16_t)(voltage * MODULE_VOLTAGE_SCALE);
+}
+
+static int16_t scale_temp(float temp_c) {
+    return (int16_t)(temp_c * MODULE_TEMP_SCALE);
+}
+
+static int16_t scale_sample(float sample_value) {
+    return (int16_t)(sample_value * MODULE_SAMPLE_SCALE);
+}
+
+static uint16_t balance_mask_from_module(size_t module_idx) {
+    uint16_t balance_mask = 0;
+
+    for (size_t cell_idx = 0; cell_idx < ADBMS6380_CELL_COUNT; cell_idx++) {
+        if (g_bms.modules[module_idx].is_discharging[cell_idx]) {
+            balance_mask |= (uint16_t)(1u << cell_idx);
+        }
+    }
+
+    return balance_mask;
+}
+
+static void send_module_voltage_stats(size_t module_idx) {
+    CAN_SEND_module_voltage_stats((uint8_t)module_idx,
+                                  scale_voltage(g_bms.modules[module_idx].min_voltage),
+                                  scale_voltage(g_bms.modules[module_idx].max_voltage),
+                                  scale_voltage(g_bms.modules[module_idx].sum_voltage));
+}
+
+static void send_module_temp_balance_stats(size_t module_idx) {
+    CAN_SEND_module_temp_balance_stats((uint8_t)module_idx,
+                                       scale_temp(g_bms.modules[module_idx].max_therm_temp),
+                                       balance_mask_from_module(module_idx));
+}
+
+static void send_individual_module_sample(size_t module_idx, bool is_temp, size_t sample_idx) {
+    if (is_temp) {
+        CAN_SEND_module_sample((uint8_t)module_idx,
+                               (uint8_t)sample_idx,
+                               true,
+                               scale_sample(g_bms.modules[module_idx].therms_temps[sample_idx]));
+        return;
+    }
+
+    CAN_SEND_module_sample((uint8_t)module_idx,
+                           (uint8_t)sample_idx,
+                           false,
+                           scale_sample(g_bms.modules[module_idx].cell_voltages[sample_idx]));
+}
 
 // Thread Defines
 DEFINE_TASK(bms_task, 200, osPriorityHigh, STACK_2048);
@@ -120,7 +179,7 @@ DEFINE_TASK(CAN_tx_update, 2, osPriorityNormal, STACK_2048);
 DEFINE_TASK(check_faults, 10, osPriorityNormal, STACK_512);
 DEFINE_TASK(charging_fsm_periodic, ELCON_COMMAND_PERIOD_MS, osPriorityNormal, STACK_512);
 DEFINE_TASK(fault_library_periodic, A_BOX_FAULT_SYNC_PERIOD_MS, osPriorityNormal, STACK_1024);
-DEFINE_TASK(report_telemetry, PACK_STATS_PERIOD_MS, osPriorityLow, STACK_512);
+DEFINE_TASK(report_telemetry, REPORT_TELEMETRY_PERIOD_MS, osPriorityLow, STACK_512);
 DEFINE_HEARTBEAT_TASK(nullptr);
 
 int main(void) {
@@ -201,9 +260,57 @@ static int16_t isense_to_current(uint16_t isense_raw) {
 }
 
 void report_telemetry() {
+    static uint32_t next_pack_stats_ms        = 0;
+    static uint32_t next_module_stats_ms      = 0;
+    static uint32_t next_sample_ms            = 0;
+    static size_t module_stats_module_idx     = 0;
+    static bool send_balance_stats_next       = false;
+    static size_t sample_module_idx           = 0;
+    static size_t sample_sensor_idx           = 0;
+    static bool sample_is_temp                = false;
+
+    uint32_t now = OS_TICKS;
+
     uint16_t pack_voltage = (uint16_t)(g_bms.sum_voltage * PACK_COEFF_PACK_STATS_PACK_VOLTAGE);
     int16_t pack_current = isense_to_current(isense_raw);
-    CAN_SEND_pack_stats(pack_voltage, pack_current, g_bms.avg_therm_temp);
+
+    while (now >= next_pack_stats_ms) {
+        CAN_SEND_pack_stats(pack_voltage, pack_current, g_bms.avg_therm_temp);
+        next_pack_stats_ms += PACK_STATS_SEND_PERIOD_MS;
+    }
+
+    while (now >= next_module_stats_ms) {
+        if (send_balance_stats_next) {
+            send_module_temp_balance_stats(module_stats_module_idx);
+            module_stats_module_idx = (module_stats_module_idx + 1) % ADBMS_MODULE_COUNT;
+        } else {
+            send_module_voltage_stats(module_stats_module_idx);
+        }
+
+        send_balance_stats_next = !send_balance_stats_next;
+        next_module_stats_ms += MODULE_STATS_SEND_PERIOD_MS;
+    }
+
+    while (now >= next_sample_ms) {
+        send_individual_module_sample(sample_module_idx, sample_is_temp, sample_sensor_idx);
+
+        if (sample_is_temp) {
+            sample_sensor_idx++;
+            if (sample_sensor_idx >= ADBMS6380_GPIO_COUNT) {
+                sample_sensor_idx = 0;
+                sample_is_temp    = false;
+                sample_module_idx = (sample_module_idx + 1) % ADBMS_MODULE_COUNT;
+            }
+        } else {
+            sample_sensor_idx++;
+            if (sample_sensor_idx >= ADBMS6380_CELL_COUNT) {
+                sample_sensor_idx = 0;
+                sample_is_temp    = true;
+            }
+        }
+
+        next_sample_ms += INDIVIDUAL_SAMPLE_SEND_PERIOD_MS;
+    }
 }
 
 void bms_task() {

--- a/source/a_box/main.c
+++ b/source/a_box/main.c
@@ -13,11 +13,11 @@
 #include "common/can_library/faults_common.h"
 #include "common/can_library/generated/A_BOX.h"
 #include "common/freertos/freertos.h"
+#include "common/heartbeat/heartbeat.h"
+#include "common/phal/adc.h"
 #include "common/phal/can.h"
 #include "common/phal/gpio.h"
 #include "common/phal/rcc.h"
-#include "common/phal/adc.h"
-#include "common/heartbeat/heartbeat.h"
 #include "telem.h"
 
 SPI_InitConfig_t bms_spi_config = {
@@ -42,15 +42,11 @@ ADCInitConfig_t adc_config = {
     .periph         = ADC1,
 };
 
-volatile uint16_t isense_raw = 0;
+volatile uint16_t isense_raw            = 0;
 ADCChannelConfig_t adc_channel_config[] = {
     {.channel = ISENSE_ADC_CHANNEL, .rank = 1, .sampling_time = ADC_CHN_SMP_CYCLES_480},
 };
-dma_init_t adc_dma_config =
-ADC1_DMA_CONT_CONFIG(
-    (uint32_t)&isense_raw,
-    1, 0b01
-);
+dma_init_t adc_dma_config = ADC1_DMA_CONT_CONFIG((uint32_t)&isense_raw, 1, 0b01);
 
 /* PER HAL Initilization Structures */
 GPIOInitConfig_t gpio_config[] = {
@@ -83,10 +79,10 @@ GPIOInitConfig_t gpio_config[] = {
     GPIO_INIT_INPUT(IMD_STATUS_PORT, IMD_STATUS_PIN, GPIO_INPUT_OPEN_DRAIN),
 
     // BMS SDC Control
-    GPIO_INIT_OUTPUT(BMS_SDC_CTRL_PORT, BMS_SDC_CTRL_PIN, GPIO_OUTPUT_LOW_SPEED)
-};
+    GPIO_INIT_OUTPUT(BMS_SDC_CTRL_PORT, BMS_SDC_CTRL_PIN, GPIO_OUTPUT_LOW_SPEED)};
 
 static constexpr uint32_t TargetCoreClockrateHz = 16'000'000;
+
 ClockRateConfig_t clock_config = {
     .clock_source           = CLOCK_SOURCE_HSE,
     .use_pll                = false,
@@ -142,19 +138,21 @@ int main(void) {
 
     adbms_init(&g_bms, &bms_spi_config, g_bms_tx_buf);
 
-    if (false == PHAL_initADC(&adc_config, adc_channel_config, sizeof(adc_channel_config) / sizeof(ADCChannelConfig_t))) {
+    if (!PHAL_initADC(&adc_config,
+                      adc_channel_config,
+                      sizeof(adc_channel_config) / sizeof(ADCChannelConfig_t))) {
         HardFault_Handler();
     }
-    if (false == PHAL_initDMA(&adc_dma_config)) {
+    if (!PHAL_initDMA(&adc_dma_config)) {
         HardFault_Handler();
     }
     PHAL_startADC(&adc_config);
     PHAL_startTxfer(&adc_dma_config);
 
-    if (false == PHAL_FDCAN_init(FDCAN1, false, VCAN_BAUD_RATE)) {
+    if (!PHAL_FDCAN_init(FDCAN1, false, VCAN_BAUD_RATE)) {
         HardFault_Handler();
     }
-    if (false == PHAL_FDCAN_init(FDCAN2, false, CCAN_BAUD_RATE)) {
+    if (!PHAL_FDCAN_init(FDCAN2, false, CCAN_BAUD_RATE)) {
         HardFault_Handler();
     }
     NVIC_SetPriority(FDCAN1_IT0_IRQn, 5);

--- a/source/a_box/main.c
+++ b/source/a_box/main.c
@@ -18,6 +18,7 @@
 #include "common/phal/rcc.h"
 #include "common/phal/adc.h"
 #include "common/heartbeat/heartbeat.h"
+#include "telem.h"
 
 SPI_InitConfig_t bms_spi_config = {
     .data_len      = 8,
@@ -106,57 +107,12 @@ uint8_t g_bms_tx_buf[ADBMS_SPI_TX_BUFFER_SIZE] = {0};
 
 static constexpr float MIN_V_FOR_BALANCE     = 3.0f;
 static constexpr float MIN_DELTA_FOR_BALANCE = 0.1f;
-static constexpr uint32_t REPORT_TELEMETRY_PERIOD_MS         = 8;
-static constexpr uint32_t PACK_STATS_SEND_PERIOD_MS          = 200;
-static constexpr uint32_t MODULE_STATS_SEND_PERIOD_MS        = 125;
-static constexpr uint32_t INDIVIDUAL_SAMPLE_SEND_PERIOD_MS   = 48;
 
 extern void HardFault_Handler(void);
 void bms_task(void);
 void check_faults(void);
 void report_telemetry(void);
 void charging_fsm_periodic(void);
-
-
-static uint16_t balance_mask_from_module(size_t module_idx) {
-    uint16_t balance_mask = 0;
-
-    for (size_t cell_idx = 0; cell_idx < ADBMS6380_CELL_COUNT; cell_idx++) {
-        if (g_bms.modules[module_idx].is_discharging[cell_idx]) {
-            balance_mask |= (uint16_t)(1u << cell_idx);
-        }
-    }
-
-    return balance_mask;
-}
-
-static void send_module_voltage_stats(size_t module_idx) {
-    CAN_SEND_module_voltage_stats((uint8_t)module_idx,
-                                  (uint16_t)(g_bms.modules[module_idx].min_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_MIN_VOLTAGE),
-                                  (uint16_t)(g_bms.modules[module_idx].max_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_MAX_VOLTAGE),
-                                  (uint16_t)(g_bms.modules[module_idx].sum_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_SUM_VOLTAGE));
-}
-
-static void send_module_temp_balance_stats(size_t module_idx) {
-    CAN_SEND_module_temp_balance_stats((uint8_t)module_idx,
-                                       (int16_t)(g_bms.modules[module_idx].max_therm_temp * PACK_COEFF_MODULE_TEMP_BALANCE_STATS_MAX_TEMP),
-                                       balance_mask_from_module(module_idx));
-}
-
-static void send_individual_module_sample(size_t module_idx, bool is_temp, size_t sample_idx) {
-    if (is_temp) {
-        CAN_SEND_module_sample((uint8_t)module_idx,
-                               (uint8_t)sample_idx,
-                               true,
-                               (int16_t)(g_bms.modules[module_idx].therms_temps[sample_idx] * PACK_COEFF_MODULE_SAMPLE_SAMPLE_VALUE));
-        return;
-    }
-
-    CAN_SEND_module_sample((uint8_t)module_idx,
-                           (uint8_t)sample_idx,
-                           false,
-                           (int16_t)(g_bms.modules[module_idx].cell_voltages[sample_idx] * PACK_COEFF_MODULE_SAMPLE_SAMPLE_VALUE));
-}
 
 // Thread Defines
 DEFINE_TASK(bms_task, 200, osPriorityHigh, STACK_2048);
@@ -165,7 +121,7 @@ DEFINE_TASK(CAN_tx_update, 2, osPriorityNormal, STACK_2048);
 DEFINE_TASK(check_faults, 10, osPriorityNormal, STACK_512);
 DEFINE_TASK(charging_fsm_periodic, ELCON_COMMAND_PERIOD_MS, osPriorityNormal, STACK_512);
 DEFINE_TASK(fault_library_periodic, A_BOX_FAULT_SYNC_PERIOD_MS, osPriorityNormal, STACK_1024);
-DEFINE_TASK(report_telemetry, REPORT_TELEMETRY_PERIOD_MS, osPriorityLow, STACK_512);
+DEFINE_TASK(report_telemetry, TELEM_REPORT_PERIOD_MS, osPriorityLow, STACK_512);
 DEFINE_HEARTBEAT_TASK(nullptr);
 
 int main(void) {
@@ -223,81 +179,6 @@ int main(void) {
     osKernelStart(); // no way home
 
     return 0;
-}
-
-// DHAB S/134 current sensor conversion
-static int16_t isense_to_current(uint16_t isense_raw) {
-    static constexpr float ADC_VREF = 3.3f;
-    static constexpr float ADC_MAX  = 4095.0f;
-
-    static constexpr float DIV_R1 = 2400.0f;
-    static constexpr float DIV_R2 = 4700.0f;
-
-    static constexpr float V_OFFSET = 2.5f;
-    static constexpr float G = 10.0e-3f;
-
-    float divider_gain = (DIV_R1 + DIV_R2) / DIV_R2;
-    float v_adc = isense_raw * ADC_VREF / ADC_MAX;
-    float v_sensor = v_adc * divider_gain;
-    float current = (v_sensor - V_OFFSET) / G;
-    float scaled_current = current * PACK_COEFF_PACK_STATS_PACK_CURRENT;
-
-    return (int16_t)scaled_current;
-}
-
-void report_telemetry() {
-    static uint32_t next_pack_stats_ms        = 0;
-    static uint32_t next_module_stats_ms      = 0;
-    static uint32_t next_sample_ms            = 0;
-    static size_t module_stats_module_idx     = 0;
-    static bool send_balance_stats_next       = false;
-    static size_t sample_module_idx           = 0;
-    static size_t sample_sensor_idx           = 0;
-    static bool sample_is_temp                = false;
-
-    uint32_t now = OS_TICKS;
-
-    uint16_t pack_voltage = (uint16_t)(g_bms.sum_voltage * PACK_COEFF_PACK_STATS_PACK_VOLTAGE);
-    int16_t pack_current = isense_to_current(isense_raw);
-    int16_t avg_temp = (int16_t)(g_bms.avg_therm_temp * PACK_COEFF_PACK_STATS_AVG_TEMP);
-
-    while (now >= next_pack_stats_ms) {
-        CAN_SEND_pack_stats(pack_voltage, pack_current, avg_temp);
-        next_pack_stats_ms += PACK_STATS_SEND_PERIOD_MS;
-    }
-
-    while (now >= next_module_stats_ms) {
-        if (send_balance_stats_next) {
-            send_module_temp_balance_stats(module_stats_module_idx);
-            module_stats_module_idx = (module_stats_module_idx + 1) % ADBMS_MODULE_COUNT;
-        } else {
-            send_module_voltage_stats(module_stats_module_idx);
-        }
-
-        send_balance_stats_next = !send_balance_stats_next;
-        next_module_stats_ms += MODULE_STATS_SEND_PERIOD_MS;
-    }
-
-    while (now >= next_sample_ms) {
-        send_individual_module_sample(sample_module_idx, sample_is_temp, sample_sensor_idx);
-
-        if (sample_is_temp) {
-            sample_sensor_idx++;
-            if (sample_sensor_idx >= ADBMS6380_GPIO_COUNT) {
-                sample_sensor_idx = 0;
-                sample_is_temp    = false;
-                sample_module_idx = (sample_module_idx + 1) % ADBMS_MODULE_COUNT;
-            }
-        } else {
-            sample_sensor_idx++;
-            if (sample_sensor_idx >= ADBMS6380_CELL_COUNT) {
-                sample_sensor_idx = 0;
-                sample_is_temp    = true;
-            }
-        }
-
-        next_sample_ms += INDIVIDUAL_SAMPLE_SEND_PERIOD_MS;
-    }
 }
 
 void bms_task() {

--- a/source/a_box/telem.c
+++ b/source/a_box/telem.c
@@ -1,0 +1,119 @@
+#include "telem.h"
+
+#include "adbms.h"
+#include "common/can_library/generated/A_BOX.h"
+
+extern adbms_bms_t g_bms;
+extern volatile uint16_t isense_raw;
+
+static constexpr uint32_t PACK_STATS_SEND_PERIOD_MS        = 200;
+static constexpr uint32_t MODULE_STATS_SEND_PERIOD_MS      = 125;
+static constexpr uint32_t INDIVIDUAL_SAMPLE_SEND_PERIOD_MS = 48;
+
+telem_state_t g_telem = {0};
+
+// DHAB S/134 current sensor conversion
+static int16_t isense_to_current(uint16_t raw_isense) {
+    static constexpr float ADC_VREF = 3.3f;
+    static constexpr float ADC_MAX  = 4095.0f;
+
+    static constexpr float DIV_R1 = 2400.0f;
+    static constexpr float DIV_R2 = 4700.0f;
+
+    static constexpr float V_OFFSET = 2.5f;
+    static constexpr float G = 10.0e-3f;
+
+    float divider_gain = (DIV_R1 + DIV_R2) / DIV_R2;
+    float v_adc = raw_isense * ADC_VREF / ADC_MAX;
+    float v_sensor = v_adc * divider_gain;
+    float current = (v_sensor - V_OFFSET) / G;
+    float scaled_current = current * PACK_COEFF_PACK_STATS_PACK_CURRENT;
+
+    return (int16_t)scaled_current;
+}
+
+static uint16_t balance_mask_from_module(size_t module_idx) {
+    uint16_t balance_mask = 0;
+
+    for (size_t cell_idx = 0; cell_idx < ADBMS6380_CELL_COUNT; cell_idx++) {
+        if (g_bms.modules[module_idx].is_discharging[cell_idx]) {
+            balance_mask |= (uint16_t)(1u << cell_idx);
+        }
+    }
+
+    return balance_mask;
+}
+
+static void send_module_voltage_stats(size_t module_idx) {
+    CAN_SEND_module_voltage_stats((uint8_t)module_idx,
+                                  (uint16_t)(g_bms.modules[module_idx].min_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_MIN_VOLTAGE),
+                                  (uint16_t)(g_bms.modules[module_idx].max_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_MAX_VOLTAGE),
+                                  (uint16_t)(g_bms.modules[module_idx].sum_voltage * PACK_COEFF_MODULE_VOLTAGE_STATS_SUM_VOLTAGE));
+}
+
+static void send_module_temp_balance_stats(size_t module_idx) {
+    CAN_SEND_module_temp_balance_stats((uint8_t)module_idx,
+                                       (int16_t)(g_bms.modules[module_idx].max_therm_temp * PACK_COEFF_MODULE_TEMP_BALANCE_STATS_MAX_TEMP),
+                                       balance_mask_from_module(module_idx));
+}
+
+static void send_individual_module_sample(size_t module_idx, bool is_temp, size_t sample_idx) {
+    if (is_temp) {
+        CAN_SEND_module_sample((uint8_t)module_idx,
+                               (uint8_t)sample_idx,
+                               true,
+                               (int16_t)(g_bms.modules[module_idx].therms_temps[sample_idx] * PACK_COEFF_MODULE_SAMPLE_SAMPLE_VALUE));
+    } else {
+
+		CAN_SEND_module_sample((uint8_t)module_idx,
+							   (uint8_t)sample_idx,
+                           	   false,
+                           	   (int16_t)(g_bms.modules[module_idx].cell_voltages[sample_idx] * PACK_COEFF_MODULE_SAMPLE_SAMPLE_VALUE));
+	}
+}
+
+void report_telemetry(void) {
+    uint32_t now = OS_TICKS;
+
+    uint16_t pack_voltage = (uint16_t)(g_bms.sum_voltage * PACK_COEFF_PACK_STATS_PACK_VOLTAGE);
+    int16_t pack_current = isense_to_current(isense_raw);
+    int16_t avg_temp = (int16_t)(g_bms.avg_therm_temp * PACK_COEFF_PACK_STATS_AVG_TEMP);
+
+    while (now >= g_telem.next_pack_stats_ms) {
+        CAN_SEND_pack_stats(pack_voltage, pack_current, avg_temp);
+        g_telem.next_pack_stats_ms += PACK_STATS_SEND_PERIOD_MS;
+    }
+
+    while (now >= g_telem.next_module_stats_ms) {
+        if (g_telem.send_balance_stats_next) {
+            send_module_temp_balance_stats(g_telem.module_stats_module_idx);
+            g_telem.module_stats_module_idx = (g_telem.module_stats_module_idx + 1) % ADBMS_MODULE_COUNT;
+        } else {
+            send_module_voltage_stats(g_telem.module_stats_module_idx);
+        }
+
+        g_telem.send_balance_stats_next = !g_telem.send_balance_stats_next;
+        g_telem.next_module_stats_ms += MODULE_STATS_SEND_PERIOD_MS;
+    }
+
+    while (now >= g_telem.next_sample_ms) {
+        send_individual_module_sample(g_telem.sample_module_idx, g_telem.sample_is_temp, g_telem.sample_sensor_idx);
+
+        if (g_telem.sample_is_temp) {
+            g_telem.sample_sensor_idx++;
+            if (g_telem.sample_sensor_idx >= ADBMS6380_GPIO_COUNT) {
+                g_telem.sample_sensor_idx = 0;
+                g_telem.sample_is_temp    = false;
+                g_telem.sample_module_idx = (g_telem.sample_module_idx + 1) % ADBMS_MODULE_COUNT;
+            }
+        } else {
+            g_telem.sample_sensor_idx++;
+            if (g_telem.sample_sensor_idx >= ADBMS6380_CELL_COUNT) {
+                g_telem.sample_sensor_idx = 0;
+                g_telem.sample_is_temp    = true;
+            }
+        }
+
+        g_telem.next_sample_ms += INDIVIDUAL_SAMPLE_SEND_PERIOD_MS;
+    }
+}

--- a/source/a_box/telem.c
+++ b/source/a_box/telem.c
@@ -2,15 +2,14 @@
 
 #include "adbms.h"
 #include "common/can_library/generated/A_BOX.h"
+#include "common/can_library/generated/VCAN.h"
 
 extern adbms_bms_t g_bms;
 extern volatile uint16_t isense_raw;
 
-static constexpr uint32_t PACK_STATS_SEND_PERIOD_MS        = 200;
-static constexpr uint32_t MODULE_STATS_SEND_PERIOD_MS      = 125;
-static constexpr uint32_t INDIVIDUAL_SAMPLE_SEND_PERIOD_MS = 48;
+static constexpr uint32_t INDIVIDUAL_SAMPLE_SEND_PERIOD_MS = 50;
 
-telem_state_t g_telem = {0};
+static telem_state_t g_telem = {0};
 
 // DHAB S/134 current sensor conversion
 static int16_t isense_to_current(uint16_t raw_isense) {
@@ -27,7 +26,7 @@ static int16_t isense_to_current(uint16_t raw_isense) {
     float v_adc = raw_isense * ADC_VREF / ADC_MAX;
     float v_sensor = v_adc * divider_gain;
     float current = (v_sensor - V_OFFSET) / G;
-    float scaled_current = current * PACK_COEFF_PACK_STATS_PACK_CURRENT;
+    float scaled_current = current * PACK_COEFF_PACK_CORE_STATS_PACK_CURRENT;
 
     return (int16_t)scaled_current;
 }
@@ -53,8 +52,16 @@ static void send_module_voltage_stats(size_t module_idx) {
 
 static void send_module_temp_balance_stats(size_t module_idx) {
     CAN_SEND_module_temp_balance_stats((uint8_t)module_idx,
+                                       (int16_t)(g_bms.modules[module_idx].min_therm_temp * PACK_COEFF_MODULE_TEMP_BALANCE_STATS_MIN_TEMP),
                                        (int16_t)(g_bms.modules[module_idx].max_therm_temp * PACK_COEFF_MODULE_TEMP_BALANCE_STATS_MAX_TEMP),
                                        balance_mask_from_module(module_idx));
+}
+
+static void send_pack_voltage_temp_stats(void) {
+    CAN_SEND_pack_voltage_temp_stats((uint16_t)(g_bms.min_voltage * PACK_COEFF_PACK_VOLTAGE_TEMP_STATS_MIN_CELL_VOLTAGE),
+                                    (uint16_t)(g_bms.max_voltage * PACK_COEFF_PACK_VOLTAGE_TEMP_STATS_MAX_CELL_VOLTAGE),
+                                    (int16_t)(g_bms.min_therm_temp * PACK_COEFF_PACK_VOLTAGE_TEMP_STATS_MIN_THERM_TEMP),
+                                    (int16_t)(g_bms.max_therm_temp * PACK_COEFF_PACK_VOLTAGE_TEMP_STATS_MAX_THERM_TEMP));
 }
 
 static void send_individual_module_sample(size_t module_idx, bool is_temp, size_t sample_idx) {
@@ -72,16 +79,19 @@ static void send_individual_module_sample(size_t module_idx, bool is_temp, size_
 	}
 }
 
+// Call at PACK_CORE_STATS_PERIOD_MS interval
 void report_telemetry(void) {
     uint32_t now = OS_TICKS;
 
-    uint16_t pack_voltage = (uint16_t)(g_bms.sum_voltage * PACK_COEFF_PACK_STATS_PACK_VOLTAGE);
+    uint16_t pack_voltage = (uint16_t)(g_bms.sum_voltage * PACK_COEFF_PACK_CORE_STATS_PACK_VOLTAGE);
     int16_t pack_current = isense_to_current(isense_raw);
-    int16_t avg_temp = (int16_t)(g_bms.avg_therm_temp * PACK_COEFF_PACK_STATS_AVG_TEMP);
+    int16_t avg_temp = (int16_t)(g_bms.avg_therm_temp * PACK_COEFF_PACK_CORE_STATS_AVG_TEMP);
 
-    while (now >= g_telem.next_pack_stats_ms) {
-        CAN_SEND_pack_stats(pack_voltage, pack_current, avg_temp);
-        g_telem.next_pack_stats_ms += PACK_STATS_SEND_PERIOD_MS;
+    CAN_SEND_pack_core_stats(pack_voltage, pack_current, avg_temp);
+
+    if (now >= g_telem.next_pack_voltage_temp_stats_ms) {
+        send_pack_voltage_temp_stats();
+        g_telem.next_pack_voltage_temp_stats_ms = now + PACK_VOLTAGE_TEMP_STATS_PERIOD_MS;
     }
 
     while (now >= g_telem.next_module_stats_ms) {
@@ -93,7 +103,7 @@ void report_telemetry(void) {
         }
 
         g_telem.send_balance_stats_next = !g_telem.send_balance_stats_next;
-        g_telem.next_module_stats_ms += MODULE_STATS_SEND_PERIOD_MS;
+        g_telem.next_module_stats_ms += MODULE_VOLTAGE_STATS_PERIOD_MS;
     }
 
     while (now >= g_telem.next_sample_ms) {

--- a/source/a_box/telem.h
+++ b/source/a_box/telem.h
@@ -1,0 +1,25 @@
+#ifndef A_BOX_TELEM_H_
+#define A_BOX_TELEM_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static constexpr uint32_t TELEM_REPORT_PERIOD_MS = 8;
+
+typedef struct {
+    uint32_t next_pack_stats_ms;
+    uint32_t next_module_stats_ms;
+    uint32_t next_sample_ms;
+    size_t module_stats_module_idx;
+    bool send_balance_stats_next;
+    size_t sample_module_idx;
+    size_t sample_sensor_idx;
+    bool sample_is_temp;
+} telem_state_t;
+
+extern telem_state_t g_telem;
+
+void report_telemetry(void);
+
+#endif

--- a/source/a_box/telem.h
+++ b/source/a_box/telem.h
@@ -5,10 +5,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static constexpr uint32_t TELEM_REPORT_PERIOD_MS = 8;
-
 typedef struct {
-    uint32_t next_pack_stats_ms;
+    uint32_t next_pack_core_stats_ms;
+    uint32_t next_pack_voltage_temp_stats_ms;
     uint32_t next_module_stats_ms;
     uint32_t next_sample_ms;
     size_t module_stats_module_idx;
@@ -18,7 +17,6 @@ typedef struct {
     bool sample_is_temp;
 } telem_state_t;
 
-extern telem_state_t g_telem;
 
 void report_telemetry(void);
 

--- a/source/dashboard/lcd/pages/race.c
+++ b/source/dashboard/lcd/pages/race.c
@@ -106,16 +106,16 @@ static inline void update_igbt_telemetry() {
 }
 
 static inline void update_pack_telemetry() {
-    if (can_data.pack_stats.is_stale()) {
+    if (can_data.pack_core_stats.is_stale()) {
         NXT_setText(BATT_VOLT, "S");
         NXT_setText(BATT_CURR, "S");
         NXT_setText(BATT_TEMP, "S");
     } else {
-        uint16_t scaled_voltage = can_data.pack_stats.pack_voltage * UNPACK_COEFF_PACK_STATS_PACK_VOLTAGE;
-        int16_t scaled_current = can_data.pack_stats.pack_current * UNPACK_COEFF_PACK_STATS_PACK_CURRENT;
+        uint16_t scaled_voltage = can_data.pack_core_stats.pack_voltage * UNPACK_COEFF_PACK_CORE_STATS_PACK_VOLTAGE;
+        int16_t scaled_current = can_data.pack_core_stats.pack_current * UNPACK_COEFF_PACK_CORE_STATS_PACK_CURRENT;
         NXT_setTextFormatted(BATT_VOLT, "%dV", scaled_voltage);
         NXT_setTextFormatted(BATT_CURR, "%dA", scaled_current);
-        NXT_setTextFormatted(BATT_TEMP, "%dC", can_data.pack_stats.avg_temp);
+        NXT_setTextFormatted(BATT_TEMP, "%dC", can_data.pack_core_stats.avg_temp);
     }
 }
 


### PR DESCRIPTION
- `pack_core_stats`: 10 ms, pack sum voltage, pack current, avg temp
- `pack_voltage_temp_stats`: 200 ms, pack min/max cells and min/max temps
- `module_voltage_stats`: 120 ms per module, min/max cell voltage, sum voltage
- module_temp_balance_stats`: 120 ms per module, min/max temp, and balancing array
- `module_sample`: 25 ms per sample (~5 sec to send all)

Does this in a rotation/round robin way.