### PR TITLE
Fix Big Endian sub-byte signals

### DIFF
--- a/can_library/canpiler/dbcgen.py
+++ b/can_library/canpiler/dbcgen.py
@@ -62,7 +62,7 @@ def generate_dbcs(context: SystemContext):
                     name=sig.name,
                     start=sig.bit_offset,
                     length=sig.length,
-                    byte_order=msg.byte_order,
+                    byte_order=sig.byte_order,
                     is_signed=sig.is_signed,
                     conversion=conversion,
                     minimum=sig.min_val,

--- a/can_library/canpiler/parser.py
+++ b/can_library/canpiler/parser.py
@@ -88,19 +88,26 @@ class Message:
             sig.length = length
             
             if self.byte_order == 'big_endian':
-                # Motorola/Big Endian: DBC start bit is the MSB position
-                # using sawtooth bit numbering
                 msb_byte = current_offset // 8
                 msb_bit_in_byte = 7 - (current_offset % 8)
-                sig.bit_offset = msb_byte * 8 + msb_bit_in_byte # DBC Motorola MSB start bit
-                sig.bit_shift = current_offset  # keep linear for C codegen
-                # Note: sub-byte signals (length < 8, not spanning byte boundaries) need no
-                # bswap as the C codegen's else branch handles them with a plain shift+mask,
-                # which is correct since memcpy into uint64_t preserves byte ordering on
-                # little-endian hosts (ARM).
+                lsb_pos = current_offset + length - 1
+                lsb_byte = lsb_pos // 8
+
+                if msb_byte == lsb_byte:
+                    # Sub-byte signal, no byte boundary crossed:
+                    # Intel (little-endian) in DBC using LSB position
+                    sig.bit_offset = current_offset # LSB position, Intel numbering
+                    sig.bit_shift = current_offset
+                    sig.byte_order = "little_endian"
+                else:
+                    # Multi-byte Motorola signal: use sawtooth MSB start bit
+                    sig.bit_offset = msb_byte * 8 + msb_bit_in_byte
+                    sig.bit_shift = current_offset
+                    sig.byte_order = "big_endian"
             else:
                 sig.bit_offset = current_offset
                 sig.bit_shift = current_offset
+                sig.byte_order = "little_endian"
                 
             sig.mask = (1 << length) - 1
             

--- a/can_library/canpiler/parser.py
+++ b/can_library/canpiler/parser.py
@@ -26,6 +26,7 @@ class Signal:
     offset: float = 0.0
     min_val: Optional[float] = None
     max_val: Optional[float] = None
+    byte_order: Literal["little_endian", "big_endian"] = "little_endian"
     
     # Resolved during parsing/linking
     bit_offset: int = 0

--- a/can_library/configs/external_nodes/ELCON_CHARGER.json
+++ b/can_library/configs/external_nodes/ELCON_CHARGER.json
@@ -20,30 +20,8 @@
                     "type": "uint16_t"
                 },
                 {
-                    "sig_name": "reserved_bit7",
-                    "type": "bool"
-                },
-                {
-                    "sig_name": "reserved_bit6",
-                    "type": "bool"
-                },
-                {
-                    "sig_name": "reserved_bit5",
-                    "type": "bool"
-                },
-                {
-                    "sig_name": "communication_fail",
-                    "sig_desc": " 5s timeout from communication failure",
-                    "type": "bool"
-                },
-                {
-                    "sig_name": "startup_fail",
-                    "sig_desc": "Startup voltage detection failure",
-                    "type": "bool"
-                },
-                {
-                    "sig_name": "input_v_fail",
-                    "sig_desc": "Input voltage failure",
+                    "sig_name": "hw_fail",
+                    "sig_desc": "Hardware failure",
                     "type": "bool"
                 },
                 {
@@ -52,8 +30,18 @@
                     "type": "bool"
                 },
                 {
-                    "sig_name": "hw_fail",
-                    "sig_desc": "Hardware failure",
+                    "sig_name": "input_v_fail",
+                    "sig_desc": "Input voltage failure",
+                    "type": "bool"
+                },
+                {
+                    "sig_name": "startup_fail",
+                    "sig_desc": "Startup voltage detection failure",
+                    "type": "bool"
+                },
+                {
+                    "sig_name": "communication_fail",
+                    "sig_desc": " 5s timeout from communication failure",
                     "type": "bool"
                 }
             ],

--- a/can_library/configs/external_nodes/IZZE_IMU.json
+++ b/can_library/configs/external_nodes/IZZE_IMU.json
@@ -5,6 +5,7 @@
         {
             "msg_name": "IZZE_angular_rate",
             "msg_desc": "Angular Rate",
+            "byte_order": "big_endian",
             "signals": [
                 {
                     "sig_name": "X_axis",
@@ -35,12 +36,12 @@
             ],
             "msg_period": 10,
             "msg_id_override": "0x4EC",
-            "msg_priority": 5,
-            "byte_order": "big_endian"
+            "msg_priority": 5
         },
         {
             "msg_name": "IZZE_acceleration",
             "msg_desc": "Acceleration",
+            "byte_order": "big_endian",
             "signals": [
                 {
                     "sig_name": "X_axis",
@@ -73,8 +74,7 @@
             ],
             "msg_period": 10,
             "msg_id_override": "0x4ED",
-            "msg_priority": 5,
-            "byte_order": "big_endian"
+            "msg_priority": 5
         }
     ],
     "rx": [


### PR DESCRIPTION
Sub-byte signals that have no byte boundary crossed are correctly handled as Intel (little-endian)