### PR TITLE
Comp26: Patch for 7 modules instead of 8

### DIFF
--- a/can_library/configs/nodes/A_BOX.json
+++ b/can_library/configs/nodes/A_BOX.json
@@ -335,7 +335,7 @@
         },
         {
             "fault_name": "PACK_FULL",
-            "max": 537,
+            "max": 470,
             "min": 0,
             "priority": "warning",
             "time_to_latch": 10000,
@@ -345,7 +345,7 @@
         {
             "fault_name": "PACK_EMPTY",
             "max": 1000,
-            "min": 380,
+            "min": 302,
             "priority": "warning",
             "time_to_latch": 10000,
             "time_to_unlatch": 10000,

--- a/source/a_box/adbms/adbms.h
+++ b/source/a_box/adbms/adbms.h
@@ -17,7 +17,7 @@
 #include "common/strbuf/strbuf.h"
 
 // Number of ADBMS modules in the daisy chain.
-#define ADBMS_MODULE_COUNT (8)
+#define ADBMS_MODULE_COUNT (7)
 
 // Number of attempts to retry a read if a PEC failure is detected before continuing.
 #define ADBMS_PEC_FAIL_MAX_RETRIES (3)


### PR DESCRIPTION
- Lower module count to 7
- Full voltage: 4.2 * 16 * 7 => 470
- Empty voltage: 2.7 * 16 * 7 => 302 volts