### PR TITLE
ci(test): auto-label PRs by changed paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# label: globs (relative to repo root) that trigger it
+"node configs":
+  - files:
+      - 'can_library/configs/**'

--- a/.github/workflows/label-changes.yml
+++ b/.github/workflows/label-changes.yml
@@ -1,0 +1,22 @@
+name: Label PRs by Changed Paths
+
+# Labeling rules live in .github/labeler.yml.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply path-based labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR from config
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
Test PR for the path-based PR labeling workflow.

This PR lands `.github/labeler.yml` and `.github/workflows/label-changes.yml` on the fork's master so the `Label PRs by Changed Paths` workflow runs against PurdueElectricRacing/firmware:master.

Purpose: verify the workflow auto-applies the `node configs` label to PRs that touch `can_library/configs/**`.

This is a throwaway test PR to be linked to / closed in favor of the real PR.