### PR TITLE
Create action and config for adding pr labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# label: globs (relative to repo root) that trigger it
+"node configs":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,3 +2,59 @@
 "node configs":
   - changed-files:
       - any-glob-to-any-file: ['can_library/configs/**']
+
+"a_box":
+  - changed-files:
+      - any-glob-to-any-file: ['source/a_box/**']
+
+"a_box config":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**/A_BOX.json']
+
+"daq":
+  - changed-files:
+      - any-glob-to-any-file: ['source/daq/**']
+
+"daq config":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**/DAQ.json']
+
+"dashboard":
+  - changed-files:
+      - any-glob-to-any-file: ['source/dashboard/**']
+
+"dashboard config":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**/DASHBOARD.json']
+
+"driveline":
+  - changed-files:
+      - any-glob-to-any-file: ['source/driveline/**']
+
+"driveline config":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**/DRIVELINE.json']
+
+"main_module":
+  - changed-files:
+      - any-glob-to-any-file: ['source/main_module/**']
+
+"main_module config":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**/MAIN_MODULE.json']
+
+"pdu":
+  - changed-files:
+      - any-glob-to-any-file: ['source/pdu/**']
+
+"pdu config":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**/PDU.json']
+
+"torque_vector":
+  - changed-files:
+      - any-glob-to-any-file: ['source/torque_vector/**']
+
+"torque_vector config":
+  - changed-files:
+      - any-glob-to-any-file: ['can_library/configs/**/TORQUE_VECTOR.json']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -58,3 +58,7 @@
 "torque_vector config":
   - changed-files:
       - any-glob-to-any-file: ['can_library/configs/**/TORQUE_VECTOR.json']
+
+"phal":
+  - changed-files:
+      - any-glob-to-any-file: ['common/phal*/**']

--- a/.github/workflows/label-changes.yml
+++ b/.github/workflows/label-changes.yml
@@ -1,0 +1,22 @@
+name: Label PRs by Changed Paths
+
+# Labeling rules live in .github/labeler.yml.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply path-based labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR from config
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
Add automatic pull-request labeling based on changed paths.

This PR:
- Adds the GitHub Actions labeler workflow.
- Retains the broad `node configs` label for `can_library/configs/**`.
- Separates each firmware component into source and CAN-config labels:
  - `a_box` / `a_box config`
  - `daq` / `daq config`
  - `dashboard` / `dashboard config`
  - `driveline` / `driveline config`
  - `main_module` / `main_module config`
  - `pdu` / `pdu config`
  - `torque_vector` / `torque_vector config`
- Adds the `phal` label for `common/phal*/**` changes.
