### PR TITLE
Add STM32G4 Internal Flash Driver + Hardware Test

### DIFF
--- a/common/phal_G4/flash/flash.c
+++ b/common/phal_G4/flash/flash.c
@@ -1,0 +1,168 @@
+#include "common/phal_G4/flash/flash.h"
+
+#include "common/phal_G4/flash/flash_priv.h"
+#include "common/phal_G4/phal_G4.h"
+
+static bool flash_range_is_valid(uint32_t address, uint32_t length_bytes) {
+    if (length_bytes == 0U) {
+        return true;
+    }
+
+    if (address < FLASH_BASE) {
+        return false;
+    }
+
+    uint32_t flash_size_bytes = FLASH_PRIV_get_size_bytes();
+    uint32_t flash_offset     = address - FLASH_BASE;
+    return flash_offset < flash_size_bytes && length_bytes <= flash_size_bytes - flash_offset;
+}
+
+static bool flash_write_range_is_valid(uint32_t address,
+                                   uint32_t length_bytes,
+                                   uint32_t *program_length_bytes) {
+    if ((address % PHAL_FLASH_WRITE_ALIGNMENT_BYTES) != 0U) {
+        return false;
+    }
+
+    if (length_bytes > UINT32_MAX - (PHAL_FLASH_WRITE_ALIGNMENT_BYTES - 1U)) {
+        return false;
+    }
+
+    *program_length_bytes =
+        (length_bytes + PHAL_FLASH_WRITE_ALIGNMENT_BYTES - 1U)
+        & ~(PHAL_FLASH_WRITE_ALIGNMENT_BYTES - 1U);
+    return flash_range_is_valid(address, *program_length_bytes);
+}
+
+static bool flash_range_is_erased(uint32_t address, uint32_t length_bytes) {
+    for (uint32_t offset = 0U; offset < length_bytes;
+         offset += PHAL_FLASH_WRITE_ALIGNMENT_BYTES) {
+        volatile const uint32_t *target = (volatile const uint32_t *)(address + offset);
+        if (target[0] != UINT32_MAX || target[1] != UINT32_MAX) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static uint64_t flash_build_double_word(const uint8_t *source, uint32_t length_bytes) {
+    uint64_t data       = UINT64_MAX;
+    uint32_t copy_bytes = length_bytes;
+    if (copy_bytes > PHAL_FLASH_WRITE_ALIGNMENT_BYTES) {
+        copy_bytes = PHAL_FLASH_WRITE_ALIGNMENT_BYTES;
+    }
+
+    for (uint32_t i = 0U; i < copy_bytes; i++) {
+        uint64_t byte_mask = (uint64_t)UINT8_MAX << (i * 8U);
+        data = (data & ~byte_mask) | ((uint64_t)source[i] << (i * 8U));
+    }
+
+    return data;
+}
+
+static bool flash_double_word_matches(uint32_t address, uint64_t expected) {
+    volatile const uint32_t *actual = (volatile const uint32_t *)address;
+    return actual[0] == (uint32_t)expected && actual[1] == (uint32_t)(expected >> 32U);
+}
+
+static bool flash_page_is_erased(uint32_t page_address, uint32_t page_size_bytes) {
+    volatile const uint32_t *page = (volatile const uint32_t *)page_address;
+    uint32_t word_count           = page_size_bytes / sizeof(uint32_t);
+
+    for (uint32_t i = 0U; i < word_count; i++) {
+        if (page[i] != UINT32_MAX) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool PHAL_FLASH_read(uint32_t address, void *destination, uint32_t length_bytes) {
+    if (length_bytes == 0U) {
+        return true;
+    }
+
+    if (destination == nullptr || !flash_range_is_valid(address, length_bytes)) {
+        return false;
+    }
+
+    if (!FLASH_PRIV_begin_read()) {
+        return false;
+    }
+
+    volatile const uint8_t *source = (volatile const uint8_t *)address;
+    uint8_t *output                = destination;
+    for (uint32_t i = 0U; i < length_bytes; i++) {
+        output[i] = source[i];
+    }
+
+    return FLASH_PRIV_end_read();
+}
+
+bool PHAL_FLASH_write(uint32_t address, const void *source, uint32_t length_bytes) {
+    if (length_bytes == 0U) {
+        return true;
+    }
+
+    uint32_t program_length_bytes = 0U;
+    if (source == nullptr
+        || !flash_write_range_is_valid(address, length_bytes, &program_length_bytes)) {
+        return false;
+    }
+
+    flash_operation_context_t context = {0};
+    if (!FLASH_PRIV_begin_operation(&context)) {
+        return false;
+    }
+
+    bool success = flash_range_is_erased(address, program_length_bytes);
+    const uint8_t *input = source;
+
+    for (uint32_t offset = 0U; success && offset < program_length_bytes;
+         offset += PHAL_FLASH_WRITE_ALIGNMENT_BYTES) {
+        uint32_t remaining_bytes = length_bytes - offset;
+        uint64_t data            = flash_build_double_word(input + offset, remaining_bytes);
+        if (data == UINT64_MAX) {
+            continue;
+        }
+
+        uint32_t target_address = address + offset;
+        success = FLASH_PRIV_program_double_word(target_address, data)
+            && flash_double_word_matches(target_address, data);
+    }
+
+    bool cleanup_success = FLASH_PRIV_end_operation(&context);
+    return success && cleanup_success;
+}
+
+bool PHAL_FLASH_erase(uint32_t address, uint32_t length_bytes) {
+    if (length_bytes == 0U) {
+        return true;
+    }
+
+    if (!flash_range_is_valid(address, length_bytes)) {
+        return false;
+    }
+
+    uint32_t page_size_bytes = FLASH_PRIV_get_page_size_bytes();
+    uint32_t flash_offset     = address - FLASH_BASE;
+    uint32_t first_page       = flash_offset / page_size_bytes;
+    uint32_t last_page        = (flash_offset + length_bytes - 1U) / page_size_bytes;
+
+    flash_operation_context_t context = {0};
+    if (!FLASH_PRIV_begin_operation(&context)) {
+        return false;
+    }
+
+    bool success = true;
+    for (uint32_t page = first_page; success && page <= last_page; page++) {
+        uint32_t page_address = FLASH_BASE + page * page_size_bytes;
+        success = FLASH_PRIV_erase_page(page_address)
+            && flash_page_is_erased(page_address, page_size_bytes);
+    }
+
+    bool cleanup_success = FLASH_PRIV_end_operation(&context);
+    return success && cleanup_success;
+}

--- a/common/phal_G4/flash/flash.h
+++ b/common/phal_G4/flash/flash.h
@@ -1,0 +1,51 @@
+#ifndef PHAL_G4_FLASH_H
+#define PHAL_G4_FLASH_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** STM32G4 flash programming granularity. */
+static constexpr uint32_t PHAL_FLASH_WRITE_ALIGNMENT_BYTES = 8U;
+
+/**
+ * @brief Copy bytes from internal flash into a buffer.
+ *
+ * The requested range must be within internal flash. A zero-length read succeeds without
+ * accessing either pointer.
+ *
+ * @param address Address of the first byte to read.
+ * @param destination Buffer that receives the data.
+ * @param length_bytes Number of bytes to read.
+ * @return true when all bytes are read; false for an invalid range, null buffer, or flash error.
+ */
+bool PHAL_FLASH_read(uint32_t address, void *destination, uint32_t length_bytes);
+
+/**
+ * @brief Program bytes into erased internal flash.
+ *
+ * The destination must be erased before writing. A zero-length write succeeds without accessing
+ * either pointer.
+ *
+ * @param address Address of the first byte to write; must be 8-byte aligned.
+ * @param source Buffer containing the data to write.
+ * @param length_bytes Number of bytes to write.
+ * @return true when all bytes are programmed and verified; false on invalid input or flash error.
+ * @note A partial final double word is padded with 0xFF.
+ */
+bool PHAL_FLASH_write(uint32_t address, const void *source, uint32_t length_bytes);
+
+/**
+ * @brief Erase every internal flash page touched by a range.
+ *
+ * The address may be unaligned. A zero-length erase succeeds without modifying flash.
+ *
+ * @param address Address of the first byte in the range.
+ * @param length_bytes Number of bytes in the range.
+ * @return true when every affected page is erased and verified; false on an invalid range or
+ * flash error.
+ * @warning Erase operates on complete pages. Bytes outside the range are erased when they share
+ * an affected page.
+ */
+bool PHAL_FLASH_erase(uint32_t address, uint32_t length_bytes);
+
+#endif // PHAL_G4_FLASH_H

--- a/common/phal_G4/flash/flash_priv.c
+++ b/common/phal_G4/flash/flash_priv.c
@@ -1,0 +1,292 @@
+#include "common/phal_G4/flash/flash_priv.h"
+
+#include "common/phal_G4/phal_G4.h"
+
+static constexpr uint32_t PHAL_FLASH_KEY_1 = 0x45670123U;
+static constexpr uint32_t PHAL_FLASH_KEY_2 = 0xCDEF89ABU;
+
+static constexpr uint32_t PHAL_FLASH_DEFAULT_SIZE_BYTES = 512U * 1024U;
+static constexpr uint32_t PHAL_FLASH_MAX_SIZE_BYTES     = 512U * 1024U;
+static constexpr uint32_t PHAL_FLASH_DUAL_PAGE_BYTES    = 2U * 1024U;
+static constexpr uint32_t PHAL_FLASH_SINGLE_PAGE_BYTES  = 4U * 1024U;
+static constexpr uint32_t PHAL_FLASH_MAX_WAIT_ITERATIONS = 170'000'000U;
+
+static constexpr uint32_t PHAL_FLASH_STATUS_ERROR_MASK = FLASH_SR_OPERR | FLASH_SR_PROGERR
+    | FLASH_SR_WRPERR | FLASH_SR_PGAERR | FLASH_SR_SIZERR | FLASH_SR_PGSERR | FLASH_SR_MISERR
+    | FLASH_SR_FASTERR | FLASH_SR_RDERR | FLASH_SR_OPTVERR;
+
+static constexpr uint32_t PHAL_FLASH_CONTROL_OPERATION_MASK = FLASH_CR_PG | FLASH_CR_PER
+    | FLASH_CR_MER1 | FLASH_CR_PNB_Msk | FLASH_CR_BKER | FLASH_CR_MER2 | FLASH_CR_FSTPG;
+
+static volatile bool g_flash_operation_active = false;
+
+static bool flash_acquire(void) {
+    uint32_t previous_interrupt_mask = __get_PRIMASK();
+    __disable_irq();
+
+    bool acquired = !g_flash_operation_active;
+    if (acquired) {
+        g_flash_operation_active = true;
+    }
+
+    __set_PRIMASK(previous_interrupt_mask);
+    return acquired;
+}
+
+static void flash_release(void) {
+    uint32_t previous_interrupt_mask = __get_PRIMASK();
+    __disable_irq();
+    g_flash_operation_active = false;
+    __set_PRIMASK(previous_interrupt_mask);
+}
+
+static bool flash_is_busy(void) {
+    return (FLASH->SR & FLASH_SR_BSY) != 0U;
+}
+
+static bool flash_wait_until_not_busy(void) {
+    uint32_t iterations_remaining = SystemCoreClock;
+    if (iterations_remaining == 0U || iterations_remaining > PHAL_FLASH_MAX_WAIT_ITERATIONS) {
+        iterations_remaining = PHAL_FLASH_MAX_WAIT_ITERATIONS;
+    }
+
+    while (flash_is_busy() && iterations_remaining > 0U) {
+        iterations_remaining--;
+    }
+
+    return !flash_is_busy();
+}
+
+static void flash_clear_status_flags(void) {
+    uint32_t clear_flags = FLASH->SR & (PHAL_FLASH_STATUS_ERROR_MASK | FLASH_SR_EOP);
+    if (clear_flags != 0U) {
+        FLASH->SR = clear_flags;
+    }
+}
+
+static bool flash_wait_for_last_operation(void) {
+    if (!flash_wait_until_not_busy()) {
+        return false;
+    }
+
+    uint32_t status = FLASH->SR;
+    uint32_t errors = status & PHAL_FLASH_STATUS_ERROR_MASK;
+    uint32_t clear_flags = errors | (status & FLASH_SR_EOP);
+    if (clear_flags != 0U) {
+        FLASH->SR = clear_flags;
+    }
+
+    return errors == 0U;
+}
+
+static bool flash_unlock(void) {
+    if ((FLASH->CR & FLASH_CR_LOCK) == 0U) {
+        return true;
+    }
+
+    FLASH->KEYR = PHAL_FLASH_KEY_1;
+    FLASH->KEYR = PHAL_FLASH_KEY_2;
+    return (FLASH->CR & FLASH_CR_LOCK) == 0U;
+}
+
+static bool flash_lock(void) {
+    FLASH->CR |= FLASH_CR_LOCK;
+    return (FLASH->CR & FLASH_CR_LOCK) != 0U;
+}
+
+static void flash_disable_data_cache(flash_operation_context_t *context) {
+    context->instruction_cache_enabled = (FLASH->ACR & FLASH_ACR_ICEN) != 0U;
+    context->data_cache_enabled        = (FLASH->ACR & FLASH_ACR_DCEN) != 0U;
+
+    if (context->data_cache_enabled) {
+        FLASH->ACR &= ~FLASH_ACR_DCEN;
+    }
+
+    __DSB();
+    __ISB();
+}
+
+static void flash_restore_caches(const flash_operation_context_t *context) {
+    if (context->instruction_cache_enabled) {
+        FLASH->ACR &= ~FLASH_ACR_ICEN;
+        FLASH->ACR |= FLASH_ACR_ICRST;
+        FLASH->ACR &= ~FLASH_ACR_ICRST;
+        FLASH->ACR |= FLASH_ACR_ICEN;
+    }
+
+    if (context->data_cache_enabled) {
+        FLASH->ACR |= FLASH_ACR_DCRST;
+        FLASH->ACR &= ~FLASH_ACR_DCRST;
+        FLASH->ACR |= FLASH_ACR_DCEN;
+    }
+
+    __DSB();
+    __ISB();
+}
+
+static bool flash_dual_bank_enabled(void) {
+    return (FLASH->OPTR & FLASH_OPTR_DBANK) != 0U;
+}
+
+static bool flash_voltage_allows_programming(void) {
+    uint32_t previous_interrupt_mask = __get_PRIMASK();
+    __disable_irq();
+
+    bool power_clock_enabled = (RCC->APB1ENR1 & RCC_APB1ENR1_PWREN) != 0U;
+    if (!power_clock_enabled) {
+        RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
+        __DSB();
+    }
+
+    bool range_one = (PWR->CR1 & PWR_CR1_VOS_Msk) == PWR_CR1_VOS_0;
+    bool range_stable = (PWR->SR2 & PWR_SR2_VOSF) == 0U;
+
+    if (!power_clock_enabled) {
+        RCC->APB1ENR1 &= ~RCC_APB1ENR1_PWREN;
+        __DSB();
+    }
+    __set_PRIMASK(previous_interrupt_mask);
+    return range_one && range_stable;
+}
+
+static bool flash_banks_swapped(void) {
+    uint32_t previous_interrupt_mask = __get_PRIMASK();
+    __disable_irq();
+
+    bool system_config_clock_enabled = (RCC->APB2ENR & RCC_APB2ENR_SYSCFGEN) != 0U;
+    if (!system_config_clock_enabled) {
+        RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+        __DSB();
+    }
+
+    bool banks_swapped = (SYSCFG->MEMRMP & SYSCFG_MEMRMP_FB_MODE) != 0U;
+
+    if (!system_config_clock_enabled) {
+        RCC->APB2ENR &= ~RCC_APB2ENR_SYSCFGEN;
+        __DSB();
+    }
+    __set_PRIMASK(previous_interrupt_mask);
+    return banks_swapped;
+}
+
+bool FLASH_PRIV_begin_read(void) {
+    if (!flash_acquire()) {
+        return false;
+    }
+
+    if (!flash_wait_until_not_busy()) {
+        flash_release();
+        return false;
+    }
+
+    flash_clear_status_flags();
+    return true;
+}
+
+bool FLASH_PRIV_end_read(void) {
+    bool success = (FLASH->SR & PHAL_FLASH_STATUS_ERROR_MASK) == 0U;
+    flash_clear_status_flags();
+    flash_release();
+    return success;
+}
+
+bool FLASH_PRIV_begin_operation(flash_operation_context_t *context) {
+    if (context == nullptr || !flash_acquire()) {
+        return false;
+    }
+
+    *context = (flash_operation_context_t) {0};
+    if (!flash_voltage_allows_programming() || !flash_wait_until_not_busy()) {
+        flash_release();
+        return false;
+    }
+
+    flash_disable_data_cache(context);
+    if (!flash_unlock()) {
+        flash_restore_caches(context);
+        flash_release();
+        return false;
+    }
+
+    FLASH->CR &= ~PHAL_FLASH_CONTROL_OPERATION_MASK;
+    flash_clear_status_flags();
+    return true;
+}
+
+bool FLASH_PRIV_end_operation(const flash_operation_context_t *context) {
+    if (context == nullptr) {
+        return false;
+    }
+
+    bool controller_idle = !flash_is_busy();
+    bool success = controller_idle && (FLASH->SR & PHAL_FLASH_STATUS_ERROR_MASK) == 0U;
+    bool locked = false;
+    if (controller_idle) {
+        FLASH->CR &= ~PHAL_FLASH_CONTROL_OPERATION_MASK;
+        flash_clear_status_flags();
+        locked = flash_lock();
+    }
+    flash_restore_caches(context);
+    flash_release();
+    return success && locked;
+}
+
+uint32_t FLASH_PRIV_get_size_bytes(void) {
+    uint32_t size_kib   = *(volatile const uint16_t *)FLASHSIZE_BASE;
+    uint32_t size_bytes = size_kib * 1024U;
+
+    if (size_kib == UINT16_MAX || size_bytes == 0U || size_bytes > PHAL_FLASH_MAX_SIZE_BYTES) {
+        return PHAL_FLASH_DEFAULT_SIZE_BYTES;
+    }
+
+    return size_bytes;
+}
+
+uint32_t FLASH_PRIV_get_page_size_bytes(void) {
+    return flash_dual_bank_enabled() ? PHAL_FLASH_DUAL_PAGE_BYTES : PHAL_FLASH_SINGLE_PAGE_BYTES;
+}
+
+bool FLASH_PRIV_program_double_word(uint32_t address, uint64_t data) {
+    flash_clear_status_flags();
+    FLASH->CR |= FLASH_CR_PG;
+
+    volatile uint32_t *destination = (volatile uint32_t *)address;
+    destination[0]                 = (uint32_t)data;
+    __ISB();
+    destination[1] = (uint32_t)(data >> 32U);
+
+    bool success = flash_wait_for_last_operation();
+    if (!flash_is_busy()) {
+        FLASH->CR &= ~FLASH_CR_PG;
+    }
+    return success;
+}
+
+bool FLASH_PRIV_erase_page(uint32_t page_address) {
+    uint32_t flash_size_bytes = FLASH_PRIV_get_size_bytes();
+    uint32_t page_size_bytes  = FLASH_PRIV_get_page_size_bytes();
+    uint32_t flash_offset     = page_address - FLASH_BASE;
+    uint32_t page             = flash_offset / page_size_bytes;
+    bool bank_two             = false;
+
+    if (flash_dual_bank_enabled()) {
+        uint32_t bank_size_bytes = flash_size_bytes / 2U;
+        bank_two                 = flash_offset >= bank_size_bytes;
+        bank_two                 = bank_two != flash_banks_swapped();
+        page                     = (flash_offset % bank_size_bytes) / page_size_bytes;
+    }
+
+    flash_clear_status_flags();
+    FLASH->CR &= ~(FLASH_CR_PNB_Msk | FLASH_CR_BKER);
+    FLASH->CR |= FLASH_CR_PER | ((page << FLASH_CR_PNB_Pos) & FLASH_CR_PNB_Msk);
+    if (bank_two) {
+        FLASH->CR |= FLASH_CR_BKER;
+    }
+    FLASH->CR |= FLASH_CR_STRT;
+
+    bool success = flash_wait_for_last_operation();
+    if (!flash_is_busy()) {
+        FLASH->CR &= ~(FLASH_CR_PER | FLASH_CR_PNB_Msk | FLASH_CR_BKER);
+    }
+    return success;
+}

--- a/common/phal_G4/flash/flash_priv.h
+++ b/common/phal_G4/flash/flash_priv.h
@@ -1,0 +1,24 @@
+#ifndef PHAL_G4_FLASH_PRIV_H
+#define PHAL_G4_FLASH_PRIV_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    bool instruction_cache_enabled;
+    bool data_cache_enabled;
+} flash_operation_context_t;
+
+bool FLASH_PRIV_begin_read(void);
+bool FLASH_PRIV_end_read(void);
+
+bool FLASH_PRIV_begin_operation(flash_operation_context_t *context);
+bool FLASH_PRIV_end_operation(const flash_operation_context_t *context);
+
+uint32_t FLASH_PRIV_get_size_bytes(void);
+uint32_t FLASH_PRIV_get_page_size_bytes(void);
+
+bool FLASH_PRIV_program_double_word(uint32_t address, uint64_t data);
+bool FLASH_PRIV_erase_page(uint32_t page_address);
+
+#endif // PHAL_G4_FLASH_PRIV_H

--- a/source/g4_testing/g4_testing.h
+++ b/source/g4_testing/g4_testing.h
@@ -11,6 +11,6 @@
 #define TEST_FLASH      6
 
 // Change this define to set the test compiled
-#define G4_TESTING_CHOSEN TEST_FLASH
+#define G4_TESTING_CHOSEN TEST_BLINKY
 
 #endif // __G4_TESTING__

--- a/source/g4_testing/g4_testing.h
+++ b/source/g4_testing/g4_testing.h
@@ -8,8 +8,9 @@
 #define TEST_SPI        3
 #define TEST_CANPILER   4
 #define IZZE_IMU_CONFIG 5
+#define TEST_FLASH      6
 
 // Change this define to set the test compiled
-#define G4_TESTING_CHOSEN TEST_BLINKY
+#define G4_TESTING_CHOSEN TEST_FLASH
 
 #endif // __G4_TESTING__

--- a/source/g4_testing/internal_flash.c
+++ b/source/g4_testing/internal_flash.c
@@ -1,0 +1,88 @@
+#include "g4_testing.h"
+#if (G4_TESTING_CHOSEN == TEST_FLASH)
+
+#include <stdint.h>
+
+#include "common/phal/flash.h"
+#include "common/phal/gpio.h"
+#include "common/phal/rcc.h"
+#include "common/utils/countof.h"
+#include "main.h"
+
+void HardFault_Handler();
+
+static constexpr uint32_t kTargetCoreClockrateHz = 16'000'000;
+ClockRateConfig_t clock_config = {
+    .clock_source           = CLOCK_SOURCE_HSI,
+    .system_clock_target_hz = kTargetCoreClockrateHz,
+    .ahb_clock_target_hz    = (kTargetCoreClockrateHz / 1),
+    .apb1_clock_target_hz   = (kTargetCoreClockrateHz / (1)),
+    .apb2_clock_target_hz   = (kTargetCoreClockrateHz / (1)),
+};
+
+#define FLASH_TEST_PAGE (FLASH_BASE + (508U * 1024U))
+
+GPIOInitConfig_t gpio_config[] = {
+    GPIO_INIT_OUTPUT(LED_GREEN_PORT, LED_GREEN_PIN, GPIO_OUTPUT_LOW_SPEED),
+    GPIO_INIT_OUTPUT(LED_RED_PORT, LED_RED_PIN, GPIO_OUTPUT_LOW_SPEED),
+};
+
+static const uint8_t g_flash_patterns[][13] = {
+    {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x0F, 0xED, 0xCB, 0xA9, 0x87},
+    {0xA5, 0x5A, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB},
+    {0xDE, 0xAD, 0xBE, 0xEF, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90},
+    {0xF0, 0x0D, 0xCA, 0xFE, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x5A},
+};
+static uint8_t g_flash_copy[sizeof(g_flash_patterns[0])] = {0};
+static uint8_t g_flash_readback[sizeof(g_flash_patterns[0])] = {0};
+
+static bool flash_copy(uint32_t source_address, uint32_t destination_address, uint32_t length_bytes) {
+    if (!PHAL_FLASH_read(source_address, g_flash_copy, length_bytes)) {
+        return false;
+    }
+    if (!PHAL_FLASH_erase(destination_address, length_bytes)) {
+        return false;
+    }
+    if (!PHAL_FLASH_write(destination_address, g_flash_copy, length_bytes)) {
+        return false;
+    }
+    if (!PHAL_FLASH_read(destination_address, g_flash_readback, length_bytes)) {
+        return false;
+    }
+
+    for (uint32_t i = 0U; i < length_bytes; i++) {
+        if (g_flash_copy[i] != g_flash_readback[i]) {
+            return false;
+        }
+    }
+
+    return true;
+} 
+
+int main() {
+    if (PHAL_configureClockRates(&clock_config)) {
+        HardFault_Handler();
+    }
+    if (!PHAL_initGPIO(gpio_config, countof(gpio_config))) {
+        HardFault_Handler();
+    }
+
+    bool match = true;
+    for (uint32_t cycle = 0U; cycle < countof(g_flash_patterns); cycle++) {
+        uint32_t source_address = (uint32_t)(uintptr_t)g_flash_patterns[cycle];
+        match = flash_copy(source_address, FLASH_TEST_PAGE, sizeof(g_flash_patterns[0])) && match;
+    }
+
+    PHAL_writeGPIO(LED_GREEN_PORT, LED_GREEN_PIN, match ? 1 : 0);
+    PHAL_writeGPIO(LED_RED_PORT, LED_RED_PIN, match ? 0 : 1);
+
+    return 0;
+}
+
+void HardFault_Handler() {
+    while (1) {
+        __asm__("nop");
+    }
+}
+
+#endif // G4_TESTING_CHOSEN == TEST_FLASH


### PR DESCRIPTION
Implemented an STM32G4 internal-flash HAL with range/alignment checks, page erase, verified double-word programming, reads, cache/controller handling, and timeout/error cleanup.

Added a four-cycle hardware copy test that reads patterns from flash into RAM, erases/writes/reads the scratch page, and verifies each write. Verified with GDB.