### PR TITLE
Add Doxygen dependency/call graphs

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -580,7 +580,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,
@@ -2650,7 +2650,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations Doxygen is allowed
 # to run in parallel. When set to 0 Doxygen will base this on the number of
@@ -2831,7 +2831,7 @@ INCLUDED_BY_GRAPH      = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALL_GRAPH             = NO
+CALL_GRAPH             = YES
 
 # If the CALLER_GRAPH tag is set to YES then Doxygen will generate a caller
 # dependency graph for every global function or class method.
@@ -2843,7 +2843,7 @@ CALL_GRAPH             = NO
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALLER_GRAPH           = NO
+CALLER_GRAPH           = YES
 
 # If the GRAPHICAL_HIERARCHY tag is set to YES then Doxygen will graphical
 # hierarchy of all classes instead of a textual one.
@@ -2887,7 +2887,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg or svg:svg or svg:svg:core, then this option
 # can be set to YES to enable generation of interactive SVG images that allow
@@ -2901,7 +2901,7 @@ DOT_IMAGE_FORMAT       = png
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INTERACTIVE_SVG        = NO
+INTERACTIVE_SVG        = YES
 
 # The DOT_PATH tag can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -556,7 +556,7 @@ TIMESTAMP              = NO
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.


### PR DESCRIPTION
Enables Doxygen dependency and call graphs.

EXTRACT_ALL: If the EXTRACT_ALL tag is set to YES, Doxygen will assume all entities in documentation are documented, even if no documentation was available.

EXTRACT_STATIC: If the EXTRACT_STATIC tag is set to YES, all static members of a file will be included in the documentation.

HAVE_DOT: If you set the HAVE_DOT tag to YES then Doxygen will assume the dot tool is available from the path. This tool is part of Graphviz (see: https://www.graphviz.org/)

CALL_GRAPH: If the CALL_GRAPH tag is set to YES then Doxygen will generate a call dependency graph for every global function or class method.

CALLER_GRAPH: If the CALLER_GRAPH tag is set to YES then Doxygen will generate a caller dependency graph for every global function or class method.

DOT_IMAGE_FORMAT = svg: Set image format from png to svg.

INTERACTIVE_SVG: If DOT_IMAGE_FORMAT is set to svg or svg:svg or svg:svg:core, then this option can be set to YES to enable generation of interactive SVG images that allow zooming and panning.