### PR TITLE
G4 ADC HAL

### DIFF
--- a/common/phal_G4/adc/adc.c
+++ b/common/phal_G4/adc/adc.c
@@ -1,207 +1,293 @@
 /**
  * @file adc.c
- * @author Eilen Yoon - Port of F4 HAL by Aditya Anand, Chris McGalliard
- * @brief
- * @version 0.1
- * @date 2023-09-17
+ * @brief G4 ADC public API implementation. All register-level detail lives
+ *        in adc_priv.c; this file only coordinates the ADC with its DMA channel.
+ * @author Ronak Jain (jain717@purdue.edu)
  */
 
 #include "common/phal_G4/adc/adc.h"
 
-// Oversample count must be 2,4,8,16,32,64,128,256
-// The shift is automatically set as log2(oversample_count)
-static bool PHAL_configureOversampling(ADCInitConfig_t* config) {
-    ADC_TypeDef* adc = config->periph;
+#include "common/phal_G4/adc/adc_priv.h"
 
-    uint16_t oversample_count = config->oversample;
-    if (oversample_count == ADC_OVERSAMPLE_NONE)
-        return true;
-    if (oversample_count < 2 || oversample_count > 256)
-        return false;
+// One active handle per ADC instance, so the DMA interrupt can find the
+// handle that owns the channel that fired.
+static PHAL_ADC_Handle_t *g_active_adc[4];
 
-    // Check power of two
-    if ((oversample_count & (oversample_count - 1)) != 0)
-        return false;
+/// USART DMA fallback used when DMA1 channel 1 is not owned by ADC1.
+extern void PHAL_USART_DMA1_Channel1_IRQHandler(void) __attribute__((weak));
 
-    // Map oversample_count to OVSR encoding:
-    // OVSR = log2(oversample_count) - 1 (0 means no oversampling)
-    // e.g. 2 => OVSR=0, 4=>1, 8=>2, 16=>3, 32=>4, 64=>5, 128=>6, 256=>7
-    uint8_t ovsr = 0;
-    uint16_t tmp = oversample_count;
-    while (tmp > 2) {
-        tmp >>= 1;
-        ovsr++;
+/// SPI DMA fallback used when DMA2 channel 3 is not owned by ADC4.
+extern void PHAL_SPI_DMA2_Channel3_IRQHandler(void) __attribute__((weak));
+
+/// Map a supported ADC instance to its zero-based active-handle slot.
+static uint8_t adc_instance_index(ADC_TypeDef *instance) {
+    if (instance == ADC1) {
+        return 0;
     }
-
-    // Shift = log2(oversample_count) (to scale sum to average)
-    uint8_t ovss = 0;
-    tmp          = oversample_count;
-    while (tmp > 1) {
-        tmp >>= 1;
-        ovss++;
+    if (instance == ADC2) {
+        return 1;
     }
-
-    // Clear previous oversampling bits
-    adc->CFGR2 &= ~(ADC_CFGR2_OVSR_Msk | ADC_CFGR2_OVSS_Msk);
-
-    // Set new oversampling ratio and shift
-    adc->CFGR2 |= (ovsr << ADC_CFGR2_OVSR_Pos) | (ovss << ADC_CFGR2_OVSS_Pos);
-
-    return true;
+    if (instance == ADC3) {
+        return 2;
+    }
+    return 3; // ADC4
 }
 
-static bool PHAL_configureADCChannels(ADCInitConfig_t* config, ADCChannelConfig_t channels[], uint8_t num_channels) {
-    ADC_TypeDef* adc = config->periph;
+/// Return the fixed DMA wiring assigned to an ADC instance.
+static const PHAL_DMA_Wiring_t *adc_dma_wiring(ADC_TypeDef *instance) {
+    switch (adc_instance_index(instance)) {
+        case 0: return &ADC1_DMA_WIRING;
+        case 1: return &ADC2_DMA_WIRING;
+        case 2: return &ADC3_DMA_WIRING;
+        default: return &ADC4_DMA_WIRING;
+    }
+}
 
-    // Clear all SQR ranks
-    adc->SQR1 = 0;
-    adc->SQR2 = 0;
-    adc->SQR3 = 0;
-    adc->SQR4 = 0;
-
-    // Set number of channels
-    adc->SQR1 |= (num_channels - 1) << ADC_SQR1_L_Pos;
-
-    // Configure sequence and sample time ---
-    for (uint8_t i = 0; i < num_channels; i++) {
-        uint8_t ch   = channels[i].channel;
-        uint8_t rank = channels[i].rank;
-        if (rank <= 0)
-            return false;
-        rank = rank - 1; // PHAL does 1-based start
-
-        // Set rank for channel
-        if (rank < 4) {
-            adc->SQR1 &= ~(0b111111 << (6 + rank * 6));
-            adc->SQR1 |= ((uint32_t)ch << (6 + rank * 6));
-        } else if (rank < 9) {
-            adc->SQR2 &= ~(0b111111 << ((rank - 4) * 6));
-            adc->SQR2 |= ((uint32_t)ch << ((rank - 4) * 6));
-        } else if (rank < 14) {
-            adc->SQR3 &= ~(0b111111 << ((rank - 9) * 6));
-            adc->SQR3 |= ((uint32_t)ch << ((rank - 9) * 6));
-        } else if (rank < 16) {
-            adc->SQR4 &= ~(0b111111 << ((rank - 14) * 6));
-            adc->SQR4 |= ((uint32_t)ch << ((rank - 14) * 6));
-        } else {
+/// Validate a public ADC configuration before touching hardware.
+static bool adc_config_is_valid(const PHAL_ADC_Config_t *config) {
+    if (config == nullptr || config->channels == nullptr) {
+        return false;
+    }
+    if (!ADC_PRIV_instance_is_supported(config->instance)) {
+        return false;
+    }
+    if (config->channel_count == 0U || config->channel_count > PHAL_ADC_MAX_CHANNEL_COUNT) {
+        return false;
+    }
+    for (size_t i = 0U; i < config->channel_count; i++) {
+        uint8_t channel = config->channels[i].channel;
+        if (channel < 1U || channel > PHAL_ADC_MAX_CHANNEL_NUMBER) {
             return false;
         }
+    }
+    return true;
+}
 
-        // Set sampling time for channel
-        if (ch <= 9) {
-            adc->SMPR1 &= ~(0b111 << (ch * 3));
-            adc->SMPR1 |= (channels[i].sampling_time << (ch * 3));
-        } else {
-            uint8_t ch2 = ch - 10;
-            adc->SMPR2 &= ~(0b111 << (ch2 * 3));
-            adc->SMPR2 |= (channels[i].sampling_time << (ch2 * 3));
+/// Return the NVIC interrupt assigned to an ADC instance's DMA channel.
+static IRQn_Type adc_dma_irqn(ADC_TypeDef *instance) {
+    const PHAL_DMA_Wiring_t *wiring = adc_dma_wiring(instance);
+    // DMA channel IRQ numbers are consecutive within each controller.
+    IRQn_Type base = (wiring->periph == DMA1) ? DMA1_Channel1_IRQn : DMA2_Channel1_IRQn;
+    return (IRQn_Type)(base + wiring->channel_idx - 1);
+}
+
+/// Enable the NVIC interrupt for an ADC instance's DMA channel.
+static void adc_nvic_enable(ADC_TypeDef *instance) {
+    NVIC_EnableIRQ(adc_dma_irqn(instance));
+}
+
+// --- transfer plumbing -------------------------------------------------------
+
+/// Atomically claim transfer completion for either polling or interrupt code.
+static bool adc_claim_completion(PHAL_ADC_Handle_t *handle) {
+    uint32_t interrupt_state = __get_PRIMASK();
+    __disable_irq();
+    bool claimed = handle->busy;
+    handle->busy = false;
+    if (interrupt_state == 0U) {
+        __enable_irq();
+    }
+    return claimed;
+}
+
+/// Stop the ADC and DMA channel, then clear the DMA status flags.
+static void adc_teardown(PHAL_ADC_Handle_t *handle) {
+    ADC_PRIV_stop_conversion(handle->config->instance);
+    PHAL_DMA_stop(&handle->dma);
+    PHAL_DMA_clearFlags(&handle->dma);
+}
+
+bool PHAL_ADC_init(PHAL_ADC_Handle_t *handle, const PHAL_ADC_Config_t *config) {
+    if (handle == nullptr || !adc_config_is_valid(config)) {
+        return false;
+    }
+    uint8_t index = adc_instance_index(config->instance);
+    if (g_active_adc[index] != nullptr) {
+        return false; // instance already claimed by another handle
+    }
+
+    if (!ADC_PRIV_configure(config->instance, config->channels, config->channel_count)) {
+        return false;
+    }
+    if (!ADC_PRIV_enable(config->instance)) {
+        return false;
+    }
+
+    handle->config         = config;
+    handle->busy           = false;
+    handle->transfer_error = false;
+    handle->dma.wiring     = adc_dma_wiring(config->instance);
+    handle->dma.params     = (PHAL_DMA_Params_t){
+        .mem_addr   = 0U,
+        .tx_size    = 0U,
+        .priority   = DMA_PRIORITY_HIGH,
+        .mode       = DMA_MODE_CIRCULAR,
+        .mem_inc    = true,
+        .tx_isr_en  = true, // transfer-complete interrupt drives the callback
+    };
+    if (!PHAL_DMA_init(&handle->dma)) {
+        ADC_PRIV_disable(config->instance);
+        handle->config = nullptr;
+        return false;
+    }
+
+    g_active_adc[index] = handle;
+    adc_nvic_enable(config->instance);
+    return true;
+}
+
+bool PHAL_ADC_readDMA(PHAL_ADC_Handle_t *handle, uint16_t *buffer, uint16_t length) {
+    if (handle == nullptr || handle->dma.channel == nullptr || buffer == nullptr) {
+        return false;
+    }
+    if (handle->busy || length == 0U || ((uint32_t)buffer & 1U) != 0U) {
+        return false;
+    }
+
+    // (Re)arm the DMA channel: fresh flags, new buffer/length, channel enabled
+    handle->dma.params.tx_size = length;
+    if (!PHAL_DMA_setMemAddress(&handle->dma, (uint32_t)buffer)
+        || !PHAL_DMA_restart(&handle->dma)) {
+        return false;
+    }
+
+    handle->busy           = true;
+    handle->transfer_error = false;
+    ADC_PRIV_prepare_transfer(handle->config->instance, true);
+    ADC_PRIV_start_conversion(handle->config->instance);
+    return true;
+}
+
+bool PHAL_ADC_readBlocking(PHAL_ADC_Handle_t *handle, uint16_t *buffer, uint16_t length, uint32_t timeout) {
+    if (handle == nullptr || handle->config == nullptr || handle->dma.channel == nullptr) {
+        return false;
+    }
+
+    // Keep completion in the caller's context. Any IRQ raised while polling is
+    // cleared after teardown, before restoring the channel's prior NVIC state.
+    IRQn_Type irqn = adc_dma_irqn(handle->config->instance);
+    bool irq_was_enabled = NVIC_GetEnableIRQ(irqn) != 0U;
+    NVIC_DisableIRQ(irqn);
+
+    if (!PHAL_ADC_readDMA(handle, buffer, length)) {
+        if (irq_was_enabled) {
+            NVIC_EnableIRQ(irqn);
         }
-    }
-
-    return true;
-}
-
-bool PHAL_initADC(ADCInitConfig_t* config, ADCChannelConfig_t channels[], uint8_t num_channels) {
-    if (num_channels >= 16)
-        return false;
-
-    ADC_TypeDef* adc = config->periph;
-    if (adc == ADC1 || adc == ADC2) {
-        // Enable clock to the selected peripheral
-        RCC->AHB2ENR |= RCC_AHB2ENR_ADC12EN;
-
-        RCC->CCIPR &= ~RCC_CCIPR_ADC12SEL; // Clear bits
-        RCC->CCIPR |= RCC_CCIPR_ADC12SEL_0; // Select system clock (PCLK) as ADC clock
-
-        ADC12_COMMON->CCR &= ~ADC_CCR_CKMODE;
-        ADC12_COMMON->CCR |= (0x1UL << ADC_CCR_CKMODE_Pos);
-        ADC12_COMMON->CCR &= ~ADC_CCR_PRESC_Msk;
-        ADC12_COMMON->CCR |= (config->prescaler << ADC_CCR_PRESC_Pos) & ADC_CCR_PRESC_Msk;
-    } else if (adc == ADC3 || adc == ADC4 || adc == ADC5) {
-        RCC->AHB2ENR |= RCC_AHB2ENR_ADC345EN;
-
-        RCC->CCIPR &= ~RCC_CCIPR_ADC345SEL;
-        RCC->CCIPR |= RCC_CCIPR_ADC345SEL_0; 
-
-        ADC345_COMMON->CCR &= ~ADC_CCR_CKMODE;
-        ADC345_COMMON->CCR |= (0x1UL << ADC_CCR_CKMODE_Pos);
-        ADC345_COMMON->CCR &= ~(ADC_CCR_PRESC_Msk);
-        ADC345_COMMON->CCR |= (config->prescaler << ADC_CCR_PRESC_Pos) & ADC_CCR_PRESC_Msk;
-    } else {
         return false;
     }
 
-    adc->CR &= ~ADC_CR_DEEPPWD;
-    adc->CR |= ADC_CR_ADVREGEN;
-    for (volatile int i = 0; i < 1000; ++i)
-        ; // Short delay
-
-    // 1. Ensure ADC is disabled before calibration
-    if (adc->CR & ADC_CR_ADEN) {
-        adc->CR |= ADC_CR_ADDIS; // Disable ADC if it was enabled
-        while (adc->CR & ADC_CR_ADEN)
-            ; // Wait until disabled
+    while (handle->busy && !PHAL_DMA_isComplete(&handle->dma)
+           && !PHAL_DMA_isError(&handle->dma) && timeout > 0U) {
+        timeout--;
     }
 
-    // Calibrate ADC
-    adc->CR |= ADC_CR_ADCAL;
-    while (adc->CR & ADC_CR_ADCAL)
-        ; // Wait for calibration to finish
+    bool claimed = adc_claim_completion(handle);
+    bool dma_error = claimed && PHAL_DMA_isError(&handle->dma);
+    bool complete = claimed && !dma_error && PHAL_DMA_isComplete(&handle->dma);
+    if (claimed) {
+        handle->transfer_error = dma_error;
+        adc_teardown(handle);
+    }
 
-    // Set conversion mode on regular channels
-    adc->CFGR &= ~(ADC_CFGR_CONT | ADC_CFGR_DISCEN);
-    config->cont_conv_mode ? (adc->CFGR |= (ADC_CFGR_CONT)) : (adc->CFGR |= (ADC_CFGR_DISCEN));
+    NVIC_ClearPendingIRQ(irqn);
+    if (irq_was_enabled) {
+        NVIC_EnableIRQ(irqn);
+    }
 
-    // Set resolution
-    adc->CFGR &= ~(ADC_CFGR_RES);
-    adc->CFGR |= (config->resolution << ADC_CFGR_RES_Pos) & ADC_CFGR_RES_Msk; // 12-bit resolution
+    if (complete) {
+        PHAL_ADC_conversionCompleteCallback(handle);
+    }
+    return complete;
+}
 
-    // Set data alignment
-    adc->CFGR &= ~(ADC_CFGR_ALIGN);
-    adc->CFGR |= (config->data_align << ADC_CFGR_ALIGN_Pos) & ADC_CFGR_ALIGN_Msk;
-
-    if (!PHAL_configureADCChannels(config, channels, num_channels))
+bool PHAL_ADC_stop(PHAL_ADC_Handle_t *handle) {
+    if (handle == nullptr || handle->dma.channel == nullptr) {
         return false;
+    }
 
-    if (!PHAL_configureOversampling(config))
+    if (adc_claim_completion(handle)) {
+        adc_teardown(handle);
+        handle->transfer_error = false;
+    }
+    return true;
+}
+
+bool PHAL_ADC_busy(const PHAL_ADC_Handle_t *handle) {
+    if (handle == nullptr) {
         return false;
-
-    adc->CFGR &= ~(ADC_CFGR_CONT | ADC_CFGR_DMAEN | ADC_CFGR_DMACFG);
-    if (config->dma_mode == ADC_DMA_ONESHOT) {
-        adc->CFGR |= ADC_CFGR_DMAEN | ADC_CFGR_DMACFG;
-    } else if (config->dma_mode == ADC_DMA_CIRCULAR) {
-        adc->CFGR |= ADC_CFGR_CONT | ADC_CFGR_DMAEN | ADC_CFGR_DMACFG;
     }
-
-    // Enable ADC
-    adc->ISR |= ADC_ISR_ADRDY; // Clear ready flag
-    adc->CR |= ADC_CR_ADEN; // Enable ADC
-    while (!(adc->ISR & ADC_ISR_ADRDY))
-        ; // Wait until ready
-
-    return true;
+    return handle->busy;
 }
 
-bool PHAL_startADC(ADCInitConfig_t* config) {
-    config->periph->CR |= ADC_CR_ADSTART;
-    return true;
+// --- interrupt handling --------------------------------------------------------
+
+/// Process DMA completion or error status for an ADC handle.
+static void adc_dma_irq_handler(PHAL_ADC_Handle_t *handle) {
+    if (handle == nullptr) {
+        return;
+    }
+
+    if (PHAL_DMA_isError(&handle->dma)) {
+        if (adc_claim_completion(handle)) {
+            handle->transfer_error = true;
+            adc_teardown(handle);
+            PHAL_ADC_conversionCompleteCallback(handle);
+        }
+        return;
+    }
+    if (!PHAL_DMA_isComplete(&handle->dma)) {
+        return;
+    }
+
+    if (handle->dma.params.mode == DMA_MODE_CIRCULAR) {
+        // Circular transfers remain active and report each completed buffer.
+        // Clear the status before invoking user code so the next wrap can
+        // raise a fresh interrupt.
+        PHAL_DMA_clearFlags(&handle->dma);
+        handle->transfer_error = false;
+        if (handle->busy) {
+            PHAL_ADC_conversionCompleteCallback(handle);
+        }
+        return;
+    }
+
+    if (adc_claim_completion(handle)) {
+        adc_teardown(handle);
+        PHAL_ADC_conversionCompleteCallback(handle);
+    }
 }
 
-bool PHAL_stopADC(ADCInitConfig_t* config) {
-    ADC_TypeDef* adc = config->periph;
-    if (adc->CR & ADC_CR_ADSTART) {
-        adc->CR |= ADC_CR_ADSTP;
+// These vectors are strong so ADC completion is deterministic. Contested
+// channels delegate to the other PHAL only when no ADC owns that DMA channel;
+// DMA channel claiming prevents both peripherals from being active at once.
+/// Dispatch DMA1 channel 1 to ADC1 or its USART3 RX fallback owner.
+void DMA1_Channel1_IRQHandler(void) {
+    if (g_active_adc[0] != nullptr) {
+        adc_dma_irq_handler(g_active_adc[0]);
+    } else if (PHAL_USART_DMA1_Channel1_IRQHandler != nullptr) {
+        PHAL_USART_DMA1_Channel1_IRQHandler();
     }
-    adc->CR &= ~ADC_CR_ADSTART;
-    return true;
 }
 
-uint16_t PHAL_readADC(ADCInitConfig_t* config) {
-    ADC_TypeDef* adc = config->periph;
-    if (!config->cont_conv_mode) {
-        adc->CR |= ADC_CR_ADSTART; // Start conversion if single-shot mode
+/// Dispatch the ADC2 DMA transfer interrupt.
+void DMA2_Channel1_IRQHandler(void) {
+    adc_dma_irq_handler(g_active_adc[1]);
+}
+
+/// Dispatch the ADC3 DMA transfer interrupt.
+void DMA2_Channel2_IRQHandler(void) {
+    adc_dma_irq_handler(g_active_adc[2]);
+}
+
+/// Dispatch DMA2 channel 3 to ADC4 or its SPI3 TX fallback owner.
+void DMA2_Channel3_IRQHandler(void) {
+    if (g_active_adc[3] != nullptr) {
+        adc_dma_irq_handler(g_active_adc[3]);
+    } else if (PHAL_SPI_DMA2_Channel3_IRQHandler != nullptr) {
+        PHAL_SPI_DMA2_Channel3_IRQHandler();
     }
-    while (!(adc->ISR & ADC_ISR_EOC))
-        ; // Wait for end of conversion
-    return (uint16_t)adc->DR; // Read result
+}
+
+[[gnu::weak]] void PHAL_ADC_conversionCompleteCallback(PHAL_ADC_Handle_t *handle) {
+    (void)handle;
 }

--- a/common/phal_G4/adc/adc.h
+++ b/common/phal_G4/adc/adc.h
@@ -1,127 +1,160 @@
 /**
  * @file adc.h
- * @author Chris McGalliard - port of L4 HAL by Luke Oxley (lcoxley@purdue.edu)
- * @brief
- * @version 0.1
- * @date 2023-09-17
+ * @brief G4 ADC public API. DMA-only, DMA-first conversions.
+ * @author Ronak Jain (jain717@purdue.edu)
  */
 
-#ifndef __PHAL_G4_ADC_H__
-#define __PHAL_G4_ADC_H__
+#ifndef PHAL_G4_ADC_H
+#define PHAL_G4_ADC_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "common/phal_G4/phal_G4.h"
 
-typedef enum {
-    ADC_RES_12_BIT = 0b00,
-    ADC_RES_10_BIT = 0b01,
-    ADC_RES_8_BIT  = 0b10,
-    ADC_RES_6_BIT  = 0b11
-} ADCResolution_t;
+#include "common/phal_G4/dma/dma.h"
 
-typedef enum {
-    ADC_CLK_PRESC_0 = 0b0000,
-    ADC_CLK_PRESC_2 = 0b0001,
-    ADC_CLK_PRESC_4 = 0b0010,
-    ADC_CLK_PRESC_6 = 0b0011,
-    ADC_CLK_PRESC_8 = 0b0100,
-} ADCClkPrescaler_t;
+/// Maximum number of channels one ADC conversion sequence can hold
+static constexpr uint8_t PHAL_ADC_MAX_CHANNEL_COUNT = 16U;
 
-typedef enum {
-    ADC_DMA_OFF      = 0b00,
-    ADC_DMA_ONESHOT  = 0b01,
-    ADC_DMA_CIRCULAR = 0b11
-} ADCDMAMode_t;
+/// Highest ADC channel number (IN18 on the G474)
+static constexpr uint8_t PHAL_ADC_MAX_CHANNEL_NUMBER = 18U;
 
-typedef enum {
-    ADC_DATA_ALIGN_RIGHT = 0b0,
-    ADC_DATA_ALIGN_LEFT  = 0b1
-} ADCDataAlign_t;
-
-typedef enum {
-    ADC_OVERSAMPLE_NONE = 0,
-    ADC_OVERSAMPLE_2    = 2,
-    ADC_OVERSAMPLE_4    = 4,
-    ADC_OVERSAMPLE_8    = 8,
-    ADC_OVERSAMPLE_16   = 16,
-    ADC_OVERSAMPLE_32   = 32,
-    ADC_OVERSAMPLE_64   = 64,
-    ADC_OVERSAMPLE_128  = 128,
-    ADC_OVERSAMPLE_256  = 256,
-} ADCOversampleCount_t;
-
+/**
+ * @brief One entry in the conversion sequence
+ *
+ * Channels are converted in array order (channels[0] first). The sampling
+ * time is fixed to the maximum (640.5 cycles) for every channel.
+ */
 typedef struct {
-    ADCClkPrescaler_t prescaler;
-    ADCResolution_t resolution;
-    ADCDataAlign_t data_align;
-    bool cont_conv_mode;
-    ADCOversampleCount_t oversample;
-    ADCDMAMode_t dma_mode;
-    ADC_TypeDef* periph;
-} ADCInitConfig_t;
+    uint8_t channel; /*!< ADC channel number, 1 - 18 (IN1..IN18) */
+} PHAL_ADC_ChannelConfig_t;
 
-typedef enum {
-    ADC_CHN_SMP_CYCLES_3   = 0b000,
-    ADC_CHN_SMP_CYCLES_15  = 0b001,
-    ADC_CHN_SMP_CYCLES_28  = 0b010,
-    ADC_CHN_SMP_CYCLES_56  = 0b011,
-    ADC_CHN_SMP_CYCLES_84  = 0b100,
-    ADC_CHN_SMP_CYCLES_112 = 0b101,
-    ADC_CHN_SMP_CYCLES_144 = 0b110,
-    ADC_CHN_SMP_CYCLES_480 = 0b111,
-} ADCChannelSampleCycles_t;
-
-typedef enum {
-    ADC_CHANNEL_1 = 1,
-    ADC_CHANNEL_2 = 2,
-    ADC_CHANNEL_3 = 3,
-    ADC_CHANNEL_4 = 4,
-} ADCChannel_t;
-
+/**
+ * @brief Static configuration for one ADC instance
+ *
+ * Everything else is fixed by the driver:
+ * - 12-bit resolution, right-aligned data
+ * - continuous conversion engine with circular DMA (each transfer keeps
+ *   refreshing the destination buffer)
+ * - ADC clock = HCLK / 4 (4 MHz @ 16 MHz HCLK, 42.5 MHz @ 170 MHz HCLK)
+ * - no oversampling, no hardware trigger (software start only)
+ */
 typedef struct {
-    ADCChannel_t channel; // not the GPIO channel, use the ADC channel
-    uint32_t rank; // order at which the channels will be polled, starting at 0
-    ADCChannelSampleCycles_t sampling_time;
-} ADCChannelConfig_t;
-
-#define ADC1_CH1_GPIO_Port (GPIOA)
-#define ADC1_CH1_Pin       (0)
-#define ADC1_CH2_GPIO_Port (GPIOA)
-#define ADC1_CH2_Pin       (1)
-#define ADC1_CH3_GPIO_Port (GPIOA)
-#define ADC1_CH3_Pin       (2)
-#define ADC1_CH4_GPIO_Port (GPIOA)
-#define ADC1_CH4_Pin       (3)
+    ADC_TypeDef *instance;               /*!< ADC1, ADC2, ADC3 or ADC4 */
+    const PHAL_ADC_ChannelConfig_t *channels; /*!< sequence, converted in array order */
+    size_t channel_count;                /*!< entries in channels[], 1 - 16 */
+} PHAL_ADC_Config_t;
 
 /**
- * @brief Initializes the ADC, requires GPIO config prior
+ * @brief Runtime handle for one ADC instance
  *
- * @param adc ADC handle
- * @param config ADC initial config settings
- * @param channels List of channel configurations
- * @param num_channels Number of channels in the channel configuration list
-**/
-bool PHAL_initADC(ADCInitConfig_t* config, ADCChannelConfig_t channels[], uint8_t num_channels);
+ * Zero-initialize (or `static` declare) and pass to PHAL_ADC_init().
+ * Do not touch the fields yourself.
+ */
+typedef struct {
+    const PHAL_ADC_Config_t *config; /*!< the config passed to PHAL_ADC_init() */
+    PHAL_DMA_Handle_t dma;           /*!< DMA channel claimed for this ADC */
+    volatile bool busy;              /*!< true while a transfer is in flight */
+    volatile bool transfer_error;    /*!< set if the last in-flight transfer hit a DMA error */
+} PHAL_ADC_Handle_t;
 
 /**
- * @brief Starts the ADC conversions, requires PHAL_initADC to be called prior
+ * @brief Configure an ADC instance and its DMA channel
  *
- * @param adc ADC handle
-**/
-bool PHAL_startADC(ADCInitConfig_t* config);
+ * What this does, in order:
+ * 1. Enables the ADC (and DMA) clocks
+ * 2. Runs the ADC hardware calibration
+ * 3. Configures the conversion sequence, sample times, and fixed conversion
+ *    options (12-bit, right-aligned, continuous, DMA-enabled, no oversampling)
+ * 4. Enables the ADC and waits until it reports ready
+ * 5. Claims the ADC's dedicated DMA channel and enables its interrupt
+ *
+ * The DMA channel is fixed per instance (ADC1 -> DMA1 ch1, ADC2 -> DMA2 ch1,
+ * ADC3 -> DMA2 ch2, ADC4 -> DMA2 ch3). Only one handle may claim each ADC
+ * instance; handles remain claimed for the lifetime of the application.
+ *
+ * @param handle zero-initialized handle to populate
+ * @param config static configuration to use; must stay valid for the
+ *        lifetime of the handle
+ * @return true on success, false if the config is invalid, the instance is
+ *         already claimed, calibration fails, or the DMA channel is taken
+ * @note Initialization configures the ADC and DMA but does not start sampling;
+ *       call PHAL_ADC_readDMA() once after initialization to start background
+ *       acquisition.
+ */
+bool PHAL_ADC_init(PHAL_ADC_Handle_t *handle, const PHAL_ADC_Config_t *config);
 
 /**
- * @brief Stops the ADC conversions, requires PHAL_initADC to be called prior
+ * @brief Start an asynchronous circular-DMA conversion into `buffer`
  *
- * @param adc ADC handle
-**/
-bool PHAL_stopADC(ADCInitConfig_t* config);
+ * The ADC continuously refreshes `buffer` and remains active until
+ * PHAL_ADC_stop() is called. `PHAL_ADC_conversionCompleteCallback()` fires
+ * (from the DMA interrupt context) after each buffer wrap.
+ *
+ * If `length` is not a multiple of the sequence length, the final burst is a
+ * partial sequence (still one sample per conversion).
+ *
+ * Fails without starting anything if a transfer is already in flight, the
+ * handle was never initialized, `buffer` is null or not halfword-aligned, or
+ * `length` is zero.
+ *
+ * @param handle initialized handle
+ * @param buffer destination, must stay valid until PHAL_ADC_stop() is called
+ * @param length number of 16-bit samples to collect (1 - 65535)
+ * @return true if the transfer was started, false otherwise
+ * @note Only one background transfer may be active for a handle.
+ */
+bool PHAL_ADC_readDMA(PHAL_ADC_Handle_t *handle, uint16_t *buffer, uint16_t length);
 
 /**
- * @brief Reads the ADC data register
+ * @brief Synchronous one-buffer conversion using the DMA engine
  *
- * @param adc ADC handle
- * @return contents of the data register
-**/
-uint16_t PHAL_readADC(ADCInitConfig_t* config);
+ * Starts the circular acquisition, blocks until one buffer has completed, then
+ * stops the acquisition. A successful transfer fires
+ * `PHAL_ADC_conversionCompleteCallback()` before returning.
+ *
+ * Note: `timeout` is a count of busy-wait iterations, not a wall-clock time.
+ * At 16 MHz one iteration is a handful of CPU cycles; the ADC itself takes
+ * roughly (640.5 + 12.5) / fADC seconds per sample (about 163 us at 4 MHz fADC).
+ *
+ * @param handle initialized handle
+ * @param buffer destination for the samples
+ * @param length number of 16-bit samples to collect
+ * @param timeout busy-wait iteration budget (0 = return immediately)
+ * @return true if all samples were collected, false on timeout or DMA error
+ */
+bool PHAL_ADC_readBlocking(PHAL_ADC_Handle_t *handle, uint16_t *buffer, uint16_t length, uint32_t timeout);
 
-#endif // __PHAL_G4_ADC_H__
+/**
+ * @brief Abort any transfer in flight and leave the ADC idle
+ *
+ * Safe to call at any time, even with no transfer running (it is then a no-op).
+ * Does not fire the completion callback.
+ *
+ * @param handle initialized handle
+ * @return true if the handle is initialized, false otherwise
+ */
+bool PHAL_ADC_stop(PHAL_ADC_Handle_t *handle);
+
+/**
+ * @brief Check whether a transfer is currently in flight
+ * @param handle initialized handle
+ * @return true while a PHAL_ADC_readDMA() transfer is running
+ */
+bool PHAL_ADC_busy(const PHAL_ADC_Handle_t *handle);
+
+/**
+ * @brief Weak callback fired once per completed DMA buffer
+ *
+ * Called from the DMA interrupt context after each asynchronous circular-DMA
+ * buffer completes, and from the caller's context at the end of a successful
+ * PHAL_ADC_readBlocking(). On a DMA error, `handle->transfer_error` is true.
+ * Keep it short; the default implementation does nothing.
+ *
+ * @param handle the handle whose transfer just completed
+ */
+extern void PHAL_ADC_conversionCompleteCallback(PHAL_ADC_Handle_t *handle);
+
+#endif // PHAL_G4_ADC_H

--- a/common/phal_G4/adc/adc_priv.c
+++ b/common/phal_G4/adc/adc_priv.c
@@ -1,0 +1,230 @@
+/**
+ * @file adc_priv.c
+ * @brief Register-level implementation of the STM32G4 ADC PHAL.
+ *
+ * All direct ADC register manipulation lives here so the public layer only
+ * coordinates the ADC with its DMA channel. Covers clocking, calibration,
+ * sequence and sampling-time programming, and bounded busy-wait start/stop
+ * helpers.
+ * @author Ronak Jain (jain717@purdue.edu)
+ */
+
+#include "common/phal_G4/adc/adc_priv.h"
+
+/// HSI16 rate, used only as a fallback when SystemCoreClock is unset
+static constexpr uint32_t ADC_PRIV_HSI_CLOCK_RATE_HZ = 16'000'000U;
+
+static constexpr uint32_t ADC_PRIV_WAIT_ITERATIONS = 100'000U;
+static constexpr uint32_t ADC_PRIV_SAMPLE_TIME_MAX = 7U;
+
+/// Return the common register bank containing an ADC instance.
+static ADC_Common_TypeDef *adc_common_registers(ADC_TypeDef *instance) {
+    return (instance == ADC1 || instance == ADC2) ? ADC12_COMMON : ADC345_COMMON;
+}
+
+/// Enable and synchronize the peripheral clock for an ADC instance.
+static void adc_enable_clock(ADC_TypeDef *instance) {
+    if (instance == ADC1 || instance == ADC2) {
+        RCC->AHB2ENR |= RCC_AHB2ENR_ADC12EN;
+    } else {
+        RCC->AHB2ENR |= RCC_AHB2ENR_ADC345EN;
+    }
+    (void)RCC->AHB2ENR;
+}
+
+/// Select the synchronous HCLK/4 ADC clock if it is not already configured.
+static void adc_configure_clock(ADC_TypeDef *instance) {
+    // CKMODE = 0b11 selects HCLK / 4. In synchronous mode PRESC is unused.
+    // Avoid rewriting the shared ADC12/ADC345 common clock while a sibling ADC
+    // may already be enabled.
+    ADC_Common_TypeDef *common = adc_common_registers(instance);
+    uint32_t clock_bits = common->CCR & (ADC_CCR_CKMODE_Msk | ADC_CCR_PRESC_Msk);
+    if (clock_bits == ADC_CCR_CKMODE_Msk) {
+        return;
+    }
+
+    uint32_t ccr = common->CCR;
+    ccr &= ~(ADC_CCR_CKMODE_Msk | ADC_CCR_PRESC_Msk);
+    ccr |= ADC_CCR_CKMODE_Msk;
+    common->CCR = ccr;
+}
+
+/// Wait for masked register bits to reach the requested state.
+static bool adc_wait_for_register(
+    volatile uint32_t *reg,
+    uint32_t mask,
+    bool expected_set
+) {
+    uint32_t iterations_remaining = ADC_PRIV_WAIT_ITERATIONS;
+    while (iterations_remaining > 0U) {
+        if (((*reg & mask) != 0U) == expected_set) {
+            return true;
+        }
+        iterations_remaining--;
+    }
+    return false;
+}
+
+/// Wait at least the ADC regulator startup interval.
+static void adc_regulator_delay(void) {
+    uint32_t clock_hz = SystemCoreClock;
+    if (clock_hz == 0U) {
+        clock_hz = ADC_PRIV_HSI_CLOCK_RATE_HZ;
+    }
+
+    uint32_t cycles = clock_hz / 50'000U;
+    if (cycles == 0U) {
+        cycles = 1U;
+    }
+
+    for (volatile uint32_t i = 0U; i < cycles; i++) {
+        __NOP();
+    }
+}
+
+/// Program one channel into a regular conversion sequence rank.
+static void adc_set_sequence_slot(ADC_TypeDef *instance, uint8_t rank, uint8_t channel) {
+    volatile uint32_t *sequence_register;
+    uint32_t shift;
+
+    if (rank <= 4U) {
+        sequence_register = &instance->SQR1;
+        shift             = 6U + 6U * (rank - 1U);
+    } else if (rank <= 9U) {
+        sequence_register = &instance->SQR2;
+        shift             = 6U * (rank - 5U);
+    } else if (rank <= 14U) {
+        sequence_register = &instance->SQR3;
+        shift             = 6U * (rank - 10U);
+    } else {
+        sequence_register = &instance->SQR4;
+        shift             = 6U * (rank - 15U);
+    }
+
+    *sequence_register = (*sequence_register & ~(0x1FU << shift))
+        | ((uint32_t)channel << shift);
+}
+
+/// Set one channel to the driver's fixed maximum sampling time.
+static void adc_set_sample_time(ADC_TypeDef *instance, uint8_t channel) {
+    volatile uint32_t *sample_register =
+        channel <= 9U ? &instance->SMPR1 : &instance->SMPR2;
+    uint32_t sample_index = channel <= 9U ? channel : channel - 10U;
+    uint32_t shift        = 3U * sample_index;
+
+    *sample_register = (*sample_register & ~(0x7U << shift))
+        | (ADC_PRIV_SAMPLE_TIME_MAX << shift);
+}
+
+/// Program the configured channel order and sampling times.
+static void adc_configure_sequence(
+    ADC_TypeDef *instance,
+    const PHAL_ADC_ChannelConfig_t *channels,
+    size_t channel_count
+) {
+    instance->SQR1 =
+        ((uint32_t)(channel_count - 1U) << ADC_SQR1_L_Pos) & ADC_SQR1_L_Msk;
+    instance->SQR2  = 0U;
+    instance->SQR3  = 0U;
+    instance->SQR4  = 0U;
+    instance->SMPR1 = 0U;
+    instance->SMPR2 = 0U;
+
+    for (size_t i = 0U; i < channel_count; i++) {
+        adc_set_sequence_slot(instance, (uint8_t)(i + 1U), channels[i].channel);
+        adc_set_sample_time(instance, channels[i].channel);
+    }
+}
+
+/// Apply the driver's fixed resolution, trigger, and DMA conversion settings.
+static void adc_configure_conversion(ADC_TypeDef *instance) {
+    uint32_t cfgr = instance->CFGR;
+    cfgr &= ~(ADC_CFGR_CONT | ADC_CFGR_DISCEN | ADC_CFGR_DMAEN
+              | ADC_CFGR_DMACFG | ADC_CFGR_RES_Msk | ADC_CFGR_ALIGN
+              | ADC_CFGR_EXTSEL_Msk | ADC_CFGR_EXTEN_Msk);
+    cfgr |= ADC_CFGR_DMAEN | ADC_CFGR_CONT | ADC_CFGR_DMACFG;
+    instance->CFGR = cfgr;
+
+    instance->CFGR2 &= ~(ADC_CFGR2_ROVSE | ADC_CFGR2_OVSR_Msk | ADC_CFGR2_OVSS_Msk);
+}
+
+/// Run single-ended ADC calibration and wait for completion.
+static bool adc_calibrate(ADC_TypeDef *instance) {
+    instance->CR &= ~ADC_CR_ADCALDIF;
+    instance->CR |= ADC_CR_ADCAL;
+    return adc_wait_for_register(&instance->CR, ADC_CR_ADCAL, false);
+}
+
+bool ADC_PRIV_instance_is_supported(ADC_TypeDef *instance) {
+    return instance == ADC1 || instance == ADC2 || instance == ADC3 || instance == ADC4;
+}
+
+bool ADC_PRIV_configure(
+    ADC_TypeDef *instance,
+    const PHAL_ADC_ChannelConfig_t *channels,
+    size_t channel_count
+) {
+    adc_enable_clock(instance);
+    if (!ADC_PRIV_disable(instance)) {
+        return false;
+    }
+    adc_configure_clock(instance);
+    instance->CR &= ~ADC_CR_DEEPPWD;
+    instance->CR |= ADC_CR_ADVREGEN;
+    adc_regulator_delay();
+
+    if (!adc_calibrate(instance)) {
+        return false;
+    }
+
+    adc_configure_conversion(instance);
+    adc_configure_sequence(instance, channels, channel_count);
+    instance->IER = 0U;
+    return true;
+}
+
+bool ADC_PRIV_enable(ADC_TypeDef *instance) {
+    instance->ISR = ADC_ISR_ADRDY | ADC_ISR_EOSMP | ADC_ISR_EOC
+        | ADC_ISR_EOS | ADC_ISR_OVR;
+    instance->CR |= ADC_CR_ADEN;
+    return adc_wait_for_register(&instance->ISR, ADC_ISR_ADRDY, true);
+}
+
+bool ADC_PRIV_disable(ADC_TypeDef *instance) {
+    if (!ADC_PRIV_stop_conversion(instance)) {
+        return false;
+    }
+    if ((instance->CR & ADC_CR_ADEN) == 0U) {
+        return true;
+    }
+
+    instance->CR |= ADC_CR_ADDIS;
+    return adc_wait_for_register(&instance->CR, ADC_CR_ADEN, false);
+}
+
+bool ADC_PRIV_is_ready(const ADC_TypeDef *instance) {
+    return (instance->CR & ADC_CR_ADEN) != 0U
+        && (instance->ISR & ADC_ISR_ADRDY) != 0U;
+}
+
+void ADC_PRIV_prepare_transfer(ADC_TypeDef *instance, bool continuous) {
+    uint32_t cfgr = instance->CFGR & ~(ADC_CFGR_CONT | ADC_CFGR_DMACFG);
+    if (continuous) {
+        cfgr |= ADC_CFGR_CONT | ADC_CFGR_DMACFG;
+    }
+    instance->CFGR = cfgr;
+    instance->ISR  = ADC_ISR_EOSMP | ADC_ISR_EOC | ADC_ISR_EOS | ADC_ISR_OVR;
+}
+
+void ADC_PRIV_start_conversion(ADC_TypeDef *instance) {
+    instance->CR |= ADC_CR_ADSTART;
+}
+
+bool ADC_PRIV_stop_conversion(ADC_TypeDef *instance) {
+    if ((instance->CR & ADC_CR_ADSTART) == 0U) {
+        return true;
+    }
+
+    instance->CR |= ADC_CR_ADSTP;
+    return adc_wait_for_register(&instance->CR, ADC_CR_ADSTART, false);
+}

--- a/common/phal_G4/adc/adc_priv.h
+++ b/common/phal_G4/adc/adc_priv.h
@@ -1,0 +1,48 @@
+/**
+ * @file adc_priv.h
+ * @brief Private register-level API for the STM32G4 ADC PHAL.
+ *
+ * Used by adc.c to drive the ADC directly: clock setup, calibration, sequence
+ * and sample-time programming, enable/disable, and conversion start/stop.
+ * Not for direct use by application code.
+ * @author Ronak Jain (jain717@purdue.edu)
+ */
+
+#ifndef PHAL_G4_ADC_PRIV_H
+#define PHAL_G4_ADC_PRIV_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/phal_G4/adc/adc.h"
+
+/// Return whether an ADC instance is supported by this driver.
+bool ADC_PRIV_instance_is_supported(ADC_TypeDef *instance);
+
+/// Configure and calibrate a disabled ADC instance.
+bool ADC_PRIV_configure(
+    ADC_TypeDef *instance,
+    const PHAL_ADC_ChannelConfig_t *channels,
+    size_t channel_count
+);
+
+/// Enable an ADC instance and wait for it to become ready.
+bool ADC_PRIV_enable(ADC_TypeDef *instance);
+
+/// Stop and disable an ADC instance.
+bool ADC_PRIV_disable(ADC_TypeDef *instance);
+
+/// Return whether an ADC instance is enabled and ready.
+bool ADC_PRIV_is_ready(const ADC_TypeDef *instance);
+
+/// Clear transfer flags and select single or continuous DMA requests.
+void ADC_PRIV_prepare_transfer(ADC_TypeDef *instance, bool continuous);
+
+/// Start the configured regular conversion sequence.
+void ADC_PRIV_start_conversion(ADC_TypeDef *instance);
+
+/// Stop an active regular conversion sequence.
+bool ADC_PRIV_stop_conversion(ADC_TypeDef *instance);
+
+#endif // PHAL_G4_ADC_PRIV_H

--- a/common/phal_G4/dma/dma.c
+++ b/common/phal_G4/dma/dma.c
@@ -134,6 +134,31 @@ bool PHAL_DMA_isBusy(PHAL_DMA_Handle_t *handle) {
     return PHAL_DMA_priv_isChannelEnabled(handle->channel);
 }
 
+bool PHAL_DMA_isComplete(PHAL_DMA_Handle_t *handle) {
+    if (handle == nullptr || handle->channel == nullptr) {
+        return false;
+    }
+
+    return PHAL_DMA_priv_readCompleteFlag(handle->wiring->periph, handle->wiring->channel_idx);
+}
+
+bool PHAL_DMA_isError(PHAL_DMA_Handle_t *handle) {
+    if (handle == nullptr || handle->channel == nullptr) {
+        return false;
+    }
+
+    return PHAL_DMA_priv_readErrorFlag(handle->wiring->periph, handle->wiring->channel_idx);
+}
+
+bool PHAL_DMA_clearFlags(PHAL_DMA_Handle_t *handle) {
+    if (handle == nullptr || handle->channel == nullptr) {
+        return false;
+    }
+
+    PHAL_DMA_priv_clearFlags(handle->wiring->periph, handle->wiring->channel_idx);
+    return true;
+}
+
 DMA_TypeDef *PHAL_DMA_getPeriph(PHAL_DMA_Handle_t *handle) {
     if (handle == nullptr || handle->channel == nullptr) {
         return nullptr;

--- a/common/phal_G4/dma/dma.h
+++ b/common/phal_G4/dma/dma.h
@@ -121,6 +121,37 @@ bool PHAL_DMA_setLength(PHAL_DMA_Handle_t *handle, uint16_t length);
 bool PHAL_DMA_isBusy(PHAL_DMA_Handle_t *handle);
 
 /**
+ * @brief Check whether the channel has finished its transfer (TC flag set)
+ *
+ * A normal-mode channel clears EN and latches this flag on its own when the
+ * transfer count reaches zero, so this is the flag a blocking wrapper should
+ * busy-wait on.
+ *
+ * @param handle initialized DMA handle
+ * @return true if the transfer-complete flag is set, false otherwise
+ */
+bool PHAL_DMA_isComplete(PHAL_DMA_Handle_t *handle);
+
+/**
+ * @brief Check whether the channel reported a transfer error (TE flag set)
+ *
+ * A bus error during the transfer latches this flag and stops the channel.
+ *
+ * @param handle initialized DMA handle
+ * @return true if the transfer-error flag is set, false otherwise
+ */
+bool PHAL_DMA_isError(PHAL_DMA_Handle_t *handle);
+
+/**
+ * @brief Clear every latched status flag (complete/error/global) for the
+ * channel, so a finished transfer can be reused
+ *
+ * @param handle initialized DMA handle
+ * @return true on success, false if handle was never successfully initialized
+ */
+bool PHAL_DMA_clearFlags(PHAL_DMA_Handle_t *handle);
+
+/**
  * @brief Get the DMA peripheral (DMA1 or DMA2) for a given handle
  * 
  * @return Return nullptr if handle is null otherwise return the DMA peripheral for the given handle

--- a/common/phal_G4/spi/spi.c
+++ b/common/phal_G4/spi/spi.c
@@ -32,9 +32,15 @@ void DMA1_Channel5_IRQHandler(void) { // example: SPI2_TX on DMA1 Ch5
     PHAL_SPI_priv_handleTxComplete(DMA1, 5);
 }
 
-[[gnu::weak]]
-void DMA2_Channel3_IRQHandler(void) { // example: SPI3_TX on DMA2 Ch3
+/// Service SPI3 TX when it owns DMA2 channel 3.
+void PHAL_SPI_DMA2_Channel3_IRQHandler(void) {
     PHAL_SPI_priv_handleTxComplete(DMA2, 3);
+}
+
+// ADC4 provides the strong shared vector when it owns DMA2 channel 3.
+[[gnu::weak]]
+void DMA2_Channel3_IRQHandler(void) {
+    PHAL_SPI_DMA2_Channel3_IRQHandler();
 }
 
 bool PHAL_SPI_init(SPI_InitConfig_t *cfg) {

--- a/common/phal_G4/usart/usart.c
+++ b/common/phal_G4/usart/usart.c
@@ -458,8 +458,15 @@ __attribute__((weak)) void DMA1_Channel2_IRQHandler(void) {
     handleDMAxComplete(DMA1, 2, USART_DMA_TX, USART3_ACTIVE_IDX);
 }
 
-void DMA1_Channel1_IRQHandler(void) {
+/// Service USART3 RX when it owns DMA1 channel 1.
+void PHAL_USART_DMA1_Channel1_IRQHandler(void) {
     handleDMAxComplete(DMA1, 1, USART_DMA_RX, USART3_ACTIVE_IDX);
+}
+
+// ADC provides the strong shared vector when linked and delegates here when
+// ADC1 does not own the channel. This weak vector covers USART-only builds.
+__attribute__((weak)) void DMA1_Channel1_IRQHandler(void) {
+    PHAL_USART_DMA1_Channel1_IRQHandler();
 }
 
 void DMA2_Channel7_IRQHandler(void) {

--- a/source/a_box/main.c
+++ b/source/a_box/main.c
@@ -59,31 +59,18 @@ SPI_InitConfig_t bms_spi_config = {
     .data_rate     = 500'000, // 500 kHz SPI clock for ADBMS6380
 };
 
-ADCInitConfig_t adc_config = {
-    .prescaler      = ADC_CLK_PRESC_2,
-    .resolution     = ADC_RES_12_BIT,
-    .data_align     = ADC_DATA_ALIGN_RIGHT,
-    .cont_conv_mode = true,
-    .dma_mode       = ADC_DMA_CIRCULAR,
-    .periph         = ADC1,
-};
-
 volatile adc1_dma_buffer_t adc1_dma_buffer;
-ADCChannelConfig_t adc_channel_config[] = {
-    {.channel = ISENSE_ADC_CHANNEL, .rank = 1, .sampling_time = ADC_CHN_SMP_CYCLES_480},
-    {.channel = VBATT_ADC_CHANNEL, .rank = 2, .sampling_time = ADC_CHN_SMP_CYCLES_480}
+
+static const PHAL_ADC_ChannelConfig_t adc_channels[] = {
+    {.channel = ISENSE_ADC_CHANNEL},
+    {.channel = VBATT_ADC_CHANNEL},
 };
-PHAL_DMA_Handle_t adc_dma_config = {
-    .wiring = &ADC1_DMA_WIRING,
-    .params = {
-        .mem_addr  = (uint32_t)&adc1_dma_buffer,
-        .tx_size   = sizeof(adc1_dma_buffer) / sizeof(uint16_t),
-        .priority  = DMA_PRIORITY_HIGH,
-        .mode      = DMA_MODE_CIRCULAR,
-        .mem_inc   = true,
-        .tx_isr_en = false,
-    },
+static const PHAL_ADC_Config_t adc_config = {
+    .instance      = ADC1,
+    .channels      = adc_channels,
+    .channel_count = sizeof(adc_channels) / sizeof(adc_channels[0]),
 };
+PHAL_ADC_Handle_t adc_handle;
 
 
 
@@ -159,14 +146,13 @@ int main(void) {
 
     adbms_init(&g_bms, &bms_spi_config, g_bms_tx_buf);
 
-    if (false == PHAL_initADC(&adc_config, adc_channel_config, countof(adc_channel_config))) {
+    if (false == PHAL_ADC_init(&adc_handle, &adc_config)) {
         HardFault_Handler();
     }
-    if (false == PHAL_DMA_init(&adc_dma_config)) {
+    if (!PHAL_ADC_readDMA(&adc_handle, (uint16_t *)&adc1_dma_buffer,
+                          sizeof(adc1_dma_buffer) / sizeof(uint16_t))) {
         HardFault_Handler();
     }
-    PHAL_startADC(&adc_config);
-    PHAL_DMA_start(&adc_dma_config);
 
     PHAL_FDCAN_init(FDCAN1, VCAN_BAUD_RATE);
     PHAL_FDCAN_init(FDCAN2, CCAN_BAUD_RATE);

--- a/source/a_box/main.h
+++ b/source/a_box/main.h
@@ -9,6 +9,7 @@
 #ifndef MAIN_H
 #define MAIN_H
 
+#include "common/phal/adc.h"
 #include "common/phal/gpio.h"
 #include "adbms.h"
 
@@ -55,6 +56,8 @@ typedef struct {
     uint16_t vbatt_raw;
 } adc1_dma_buffer_t;
 extern volatile adc1_dma_buffer_t adc1_dma_buffer;
+
+extern PHAL_ADC_Handle_t adc_handle;
 
 extern adbms_bms_t g_bms;
 

--- a/source/dashboard/main.c
+++ b/source/dashboard/main.c
@@ -83,43 +83,28 @@ GPIOInitConfig_t gpio_config[] = {
 };
 
 /* ADC Configuration */
-ADCInitConfig_t adc_config = {
-    .prescaler      = ADC_CLK_PRESC_2,
-    .resolution     = ADC_RES_12_BIT,
-    .data_align     = ADC_DATA_ALIGN_RIGHT,
-    .cont_conv_mode = true,
-    .dma_mode       = ADC_DMA_CIRCULAR,
-    .periph         = ADC1,
+static const PHAL_ADC_ChannelConfig_t adc_channels[] = {
+    {.channel = THROTTLE1_ADC_CHANNEL},
+    {.channel = THROTTLE2_ADC_CHANNEL},
+    {.channel = REGEN1_ADC_CHANNEL},
+    {.channel = REGEN2_ADC_CHANNEL},
+    {.channel = BRAKE1_PRESSURE_ADC_CHANNEL},
+    {.channel = BRAKE2_PRESSURE_ADC_CHANNEL},
 };
-
-ADCChannelConfig_t adc_channel_config[] = {
-    {.channel = THROTTLE1_ADC_CHANNEL, .rank = 1, .sampling_time = ADC_CHN_SMP_CYCLES_480},
-    {.channel = THROTTLE2_ADC_CHANNEL, .rank = 2, .sampling_time = ADC_CHN_SMP_CYCLES_480},
-    {.channel = REGEN1_ADC_CHANNEL, .rank = 3, .sampling_time = ADC_CHN_SMP_CYCLES_480},
-    {.channel = REGEN2_ADC_CHANNEL, .rank = 4, .sampling_time = ADC_CHN_SMP_CYCLES_480},
-    {.channel = BRAKE1_PRESSURE_ADC_CHANNEL, .rank = 5, .sampling_time = ADC_CHN_SMP_CYCLES_480},
-    {.channel = BRAKE2_PRESSURE_ADC_CHANNEL, .rank = 6, .sampling_time = ADC_CHN_SMP_CYCLES_480}
+static const PHAL_ADC_Config_t adc_config = {
+    .instance      = ADC1,
+    .channels      = adc_channels,
+    .channel_count = sizeof(adc_channels) / sizeof(adc_channels[0]),
 };
 
 static_assert(
     (sizeof(raw_adc_values_t) / sizeof(uint16_t)) ==
-    (sizeof(adc_channel_config) / sizeof(ADCChannelConfig_t)),
+    (sizeof(adc_channels) / sizeof(adc_channels[0])),
     "ADC channel config and raw ADC values struct must have the same number of channels"
 );
 
 volatile raw_adc_values_t raw_adc_values; // DMA target
-
-PHAL_DMA_Handle_t adc_dma_config = {
-    .wiring = &ADC1_DMA_WIRING,
-    .params = {
-        .mem_addr  = (uint32_t)&raw_adc_values,
-        .tx_size   = sizeof(raw_adc_values) / sizeof(uint16_t),
-        .priority  = DMA_PRIORITY_HIGH,
-        .mode      = DMA_MODE_CIRCULAR,
-        .mem_inc   = true,
-        .tx_isr_en = false,
-    },
-};
+PHAL_ADC_Handle_t adc_handle;
 
 // USART Configuration for LCD
 PHAL_DMA_Handle_t usart_tx_dma = {
@@ -187,14 +172,13 @@ int main(void) {
     if (false == PHAL_initUSART(&lcd, PHAL_RCC_getAPB2ClockHz())) {
         HardFault_Handler();
     }
-    if (false == PHAL_initADC(&adc_config, adc_channel_config, countof(adc_channel_config))) {
+    if (false == PHAL_ADC_init(&adc_handle, &adc_config)) {
         HardFault_Handler();
     }
-    if (false == PHAL_DMA_init(&adc_dma_config)) {
+    if (!PHAL_ADC_readDMA(&adc_handle, (uint16_t *)&raw_adc_values,
+                          sizeof(raw_adc_values) / sizeof(uint16_t))) {
         HardFault_Handler();
     }
-    PHAL_DMA_start(&adc_dma_config);
-    PHAL_startADC(&adc_config);
 
     PHAL_FDCAN_init(FDCAN2, VCAN_BAUD_RATE);
     PHAL_FDCAN_init(FDCAN3, SCAN_BAUD_RATE);

--- a/source/dashboard/main.h
+++ b/source/dashboard/main.h
@@ -11,6 +11,7 @@
 #define MAIN_H
 
 #include <stdint.h>
+#include "common/phal/adc.h"
 #include "common/phal/gpio.h"
 
 typedef volatile struct {
@@ -22,6 +23,8 @@ typedef volatile struct {
     uint16_t brake2_pressure;
 } raw_adc_values_t;
 extern volatile raw_adc_values_t raw_adc_values;
+
+extern PHAL_ADC_Handle_t adc_handle;
 
 // On-board Status LEDs
 #define CONNECTION_LED_PORT (GPIOB)

--- a/source/driveline/main.c
+++ b/source/driveline/main.c
@@ -47,134 +47,73 @@ GPIOInitConfig_t gpio_config[] = {
 /* ADC Configuration */
 
 // ADC 1
-ADCInitConfig_t adc1_config = {
-    .prescaler      = ADC_CLK_PRESC_2,
-    .resolution     = ADC_RES_12_BIT,
-    .data_align     = ADC_DATA_ALIGN_RIGHT,
-    .cont_conv_mode = true,
-    .dma_mode       = ADC_DMA_CIRCULAR,
-    .periph         = ADC1,
+static const PHAL_ADC_ChannelConfig_t adc1_channels[] = {
+    {.channel = OIL_TEMP_L_ADC_CH},
 };
-
-ADCChannelConfig_t adc1_channel_config[] = {
- {.channel = OIL_TEMP_L_ADC_CH, .rank = 1, .sampling_time = ADC_CHN_SMP_CYCLES_480},
-}; 
+static const PHAL_ADC_Config_t adc1_config = {
+    .instance      = ADC1,
+    .channels      = adc1_channels,
+    .channel_count = sizeof(adc1_channels) / sizeof(adc1_channels[0]),
+};
 typedef struct {
     uint16_t oil_temp_left;
 } raw_adc1_values_t;
 volatile raw_adc1_values_t raw_adc1_values;
+static PHAL_ADC_Handle_t adc1_handle;
 
-PHAL_DMA_Handle_t adc1_dma = {
-    .wiring = &ADC1_DMA_WIRING,
-    .params = {
-        .mem_addr  = (uint32_t)&raw_adc1_values,
-        .tx_size   = sizeof(raw_adc1_values) / sizeof(uint16_t),
-        .priority  = DMA_PRIORITY_HIGH,
-        .mode      = DMA_MODE_CIRCULAR,
-        .mem_inc   = true,
-        .tx_isr_en = false,
-    },
-};
-
-
-ADCInitConfig_t adc2_config = {
-    .prescaler      = ADC_CLK_PRESC_2,
-    .resolution     = ADC_RES_12_BIT,
-    .data_align     = ADC_DATA_ALIGN_RIGHT,
-    .cont_conv_mode = true,
-    .dma_mode       = ADC_DMA_CIRCULAR,
-    .periph         = ADC2,
-};
 
 // ADC 2
-ADCChannelConfig_t adc2_channel_config[] = {
-{.channel = OIL_TEMP_R_ADC_CH, .rank = 1, .sampling_time = ADC_CHN_SMP_CYCLES_480},
+static const PHAL_ADC_ChannelConfig_t adc2_channels[] = {
+    {.channel = OIL_TEMP_R_ADC_CH},
+};
+static const PHAL_ADC_Config_t adc2_config = {
+    .instance      = ADC2,
+    .channels      = adc2_channels,
+    .channel_count = sizeof(adc2_channels) / sizeof(adc2_channels[0]),
 };
 typedef struct {
     uint16_t oil_temp_right;
 } raw_adc2_values_t;
 volatile raw_adc2_values_t raw_adc2_values;
-
-PHAL_DMA_Handle_t adc2_dma = {
-    .wiring = &ADC2_DMA_WIRING,
-    .params = {
-        .mem_addr  = (uint32_t)&raw_adc2_values,
-        .tx_size   = sizeof(raw_adc2_values) / sizeof(uint16_t),
-        .priority  = DMA_PRIORITY_HIGH,
-        .mode      = DMA_MODE_CIRCULAR,
-        .mem_inc   = true,
-        .tx_isr_en = false,
-    },
-};
+static PHAL_ADC_Handle_t adc2_handle;
 
 
 // ADC 3
 
-ADCInitConfig_t adc3_config = {
-    .prescaler      = ADC_CLK_PRESC_2,
-    .resolution     = ADC_RES_12_BIT,
-    .data_align     = ADC_DATA_ALIGN_RIGHT,
-    .cont_conv_mode = true,
-    .dma_mode       = ADC_DMA_CIRCULAR,
-    .periph         = ADC3,
+static const PHAL_ADC_ChannelConfig_t adc3_channels[] = {
+    {.channel = SHOCKPOT_LEFT_ADC_CHNL},
 };
-
-ADCChannelConfig_t adc3_channel_config[] = {
-    {.channel = SHOCKPOT_LEFT_ADC_CHNL, .rank = 1, .sampling_time = ADC_CHN_SMP_CYCLES_480},
+static const PHAL_ADC_Config_t adc3_config = {
+    .instance      = ADC3,
+    .channels      = adc3_channels,
+    .channel_count = sizeof(adc3_channels) / sizeof(adc3_channels[0]),
 };
-
 typedef struct {
     uint16_t shock_l;
 } raw_adc3_values_t;
 volatile raw_adc3_values_t raw_adc3_values;
-
-PHAL_DMA_Handle_t adc3_dma = {
-    .wiring = &ADC3_DMA_WIRING,
-    .params = {
-        .mem_addr  = (uint32_t)&raw_adc3_values,
-        .tx_size   = sizeof(raw_adc3_values) / sizeof(uint16_t),
-        .priority  = DMA_PRIORITY_HIGH,
-        .mode      = DMA_MODE_CIRCULAR,
-        .mem_inc   = true,
-        .tx_isr_en = false,
-    },
-};
+static PHAL_ADC_Handle_t adc3_handle;
 
 // ADC 4
 
-ADCInitConfig_t adc4_config = {
-    .prescaler      = ADC_CLK_PRESC_2,
-    .resolution     = ADC_RES_12_BIT,
-    .data_align     = ADC_DATA_ALIGN_RIGHT,
-    .cont_conv_mode = true,
-    .dma_mode       = ADC_DMA_CIRCULAR,
-    .periph         = ADC4,
+static const PHAL_ADC_ChannelConfig_t adc4_channels[] = {
+    {.channel = SHOCKPOT_RIGHT_ADC_CHNL},
 };
-
-ADCChannelConfig_t adc4_channel_config[] = {
-    {.channel = SHOCKPOT_RIGHT_ADC_CHNL, .rank = 1, .sampling_time = ADC_CHN_SMP_CYCLES_480},
+static const PHAL_ADC_Config_t adc4_config = {
+    .instance      = ADC4,
+    .channels      = adc4_channels,
+    .channel_count = sizeof(adc4_channels) / sizeof(adc4_channels[0]),
 };
-
 typedef struct {
     uint16_t shock_r;
 } raw_adc4_values_t;
 volatile raw_adc4_values_t raw_adc4_values;
-PHAL_DMA_Handle_t adc4_dma = {
-    .wiring = &ADC4_DMA_WIRING,
-    .params = {
-        .mem_addr  = (uint32_t)&raw_adc4_values,
-        .tx_size   = sizeof(raw_adc4_values) / sizeof(uint16_t),
-        .priority  = DMA_PRIORITY_HIGH,
-        .mode      = DMA_MODE_CIRCULAR,
-        .mem_inc   = true,
-        .tx_isr_en = false,
-    },
-};
+static PHAL_ADC_Handle_t adc4_handle;
 
 
-// note: this struct is the target of the DMA controller,
-// it's layout must match the order and size of the ADC channels in adc_channel_config
-// additonally, it must have no padding and members must be uint16_t to match the ADC resolution and data alignment
+// note: the raw_*_values structs are the DMA destinations for each ADC's
+// read, so their layout must match the channel order and they must be
+// uint16_t-aligned (a single uint16_t member is both)
 
 
 extern void HardFault_Handler();
@@ -195,40 +134,24 @@ int main(void) {
     if (false == PHAL_initGPIO(gpio_config, countof(gpio_config))) {
         HardFault_Handler();
     }
-    if (false == PHAL_DMA_init(&adc1_dma)) {
+    if (false == PHAL_ADC_init(&adc1_handle, &adc1_config)) {
         HardFault_Handler();
     }
-    if (false == PHAL_DMA_init(&adc2_dma)) {
+    if (false == PHAL_ADC_init(&adc2_handle, &adc2_config)) {
         HardFault_Handler();
     }
-    if (false == PHAL_DMA_init(&adc3_dma)) {
+    if (false == PHAL_ADC_init(&adc3_handle, &adc3_config)) {
         HardFault_Handler();
     }
-    if (false == PHAL_DMA_init(&adc4_dma)) {
+    if (false == PHAL_ADC_init(&adc4_handle, &adc4_config)) {
         HardFault_Handler();
     }
-    if (false == PHAL_initADC(&adc1_config, adc1_channel_config, countof(adc1_channel_config))) {
+    if (!PHAL_ADC_readDMA(&adc1_handle, (uint16_t *)&raw_adc1_values, 1U)
+        || !PHAL_ADC_readDMA(&adc2_handle, (uint16_t *)&raw_adc2_values, 1U)
+        || !PHAL_ADC_readDMA(&adc3_handle, (uint16_t *)&raw_adc3_values, 1U)
+        || !PHAL_ADC_readDMA(&adc4_handle, (uint16_t *)&raw_adc4_values, 1U)) {
         HardFault_Handler();
     }
-    if (false == PHAL_initADC(&adc2_config, adc2_channel_config, countof(adc2_channel_config))) {
-        HardFault_Handler();
-    }
-    if (false == PHAL_initADC(&adc3_config, adc3_channel_config, countof(adc3_channel_config))) {
-        HardFault_Handler();
-    }
-    if (false == PHAL_initADC(&adc4_config, adc4_channel_config, countof(adc4_channel_config))) {
-        HardFault_Handler();
-    }
-    
-    PHAL_DMA_start(&adc1_dma);
-    PHAL_DMA_start(&adc2_dma);
-    PHAL_DMA_start(&adc3_dma);
-    PHAL_DMA_start(&adc4_dma);
-
-    PHAL_startADC(&adc1_config);
-    PHAL_startADC(&adc2_config);
-    PHAL_startADC(&adc3_config);
-    PHAL_startADC(&adc4_config);
 
     PHAL_FDCAN_init(FDCAN2, VCAN_BAUD_RATE);
     CAN_init();

--- a/source/g4_testing/adc_test.c
+++ b/source/g4_testing/adc_test.c
@@ -1,0 +1,202 @@
+/**
+ * @file adc_test.c
+ * @brief G4 ADC loopback test verifying end-to-end conversion accuracy.
+ *
+ * PA4 (DAC1_OUT1) must be wired to PA0 (ADC1_IN1). The test sweeps 12-bit DAC
+ * codes, reads each back with an asynchronous DMA conversion, and checks the
+ * error against a fixed tolerance. Green LED = pass, red LED = failure.
+ * @author Ronak Jain (jain717@purdue.edu)
+ */
+
+#include "g4_testing.h"
+#if (G4_TESTING_CHOSEN == TEST_ADC)
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "common/phal/rcc.h"
+#include "common/phal_G4/adc/adc.h"
+#include "common/phal_G4/gpio/gpio.h"
+#include "common/utils/countof.h"
+#include "main.h"
+
+/**
+ * Connect PA4 (DAC1_OUT1) to PA0 (ADC1_IN1) before running this test.
+ * The green LED indicates that every DAC code was read within tolerance; the
+ * red LED indicates initialization, timeout, DMA, or conversion failure.
+ */
+
+static constexpr uint32_t ADC_TEST_DMA_TIMEOUT        = 1'000'000U;
+static constexpr uint32_t ADC_TEST_DAC_SETTLE_CYCLES  = 10'000U;
+static constexpr uint16_t ADC_TEST_ALLOWED_ERROR      = 48U;
+static constexpr uint8_t ADC_TEST_INPUT_CHANNEL       = 1U;
+
+static GPIOInitConfig_t gpio_config[] = {
+    GPIO_INIT_ANALOG(GPIOA, 0),
+    GPIO_INIT_ANALOG(GPIOA, 4),
+    GPIO_INIT_OUTPUT(LED_GREEN_PORT, LED_GREEN_PIN, GPIO_OUTPUT_LOW_SPEED),
+    GPIO_INIT_OUTPUT(LED_RED_PORT, LED_RED_PIN, GPIO_OUTPUT_LOW_SPEED),
+};
+
+static const PHAL_ADC_ChannelConfig_t adc_channels[] = {
+    {.channel = ADC_TEST_INPUT_CHANNEL},
+};
+
+static const PHAL_ADC_Config_t adc_config = {
+    .instance      = ADC1,
+    .channels      = adc_channels,
+    .channel_count = sizeof(adc_channels) / sizeof(adc_channels[0]),
+};
+
+static const uint16_t dac_test_codes[] = {
+    256U,
+    1024U,
+    2048U,
+    3072U,
+    3840U,
+};
+
+static PHAL_ADC_Handle_t adc_handle;
+static uint16_t adc_sample;
+
+volatile uint16_t adc_test_expected;
+volatile uint16_t adc_test_actual;
+volatile uint16_t adc_test_error;
+volatile uint32_t adc_test_failed_index = UINT32_MAX;
+volatile bool adc_test_passed;
+
+static volatile bool adc_test_conversion_complete;
+static volatile bool adc_test_conversion_error;
+static uint32_t adc_test_index;
+static uint32_t adc_test_wait_iterations;
+static bool adc_test_conversion_started;
+
+typedef enum {
+    ADC_TEST_RUNNING,
+    ADC_TEST_PASS,
+    ADC_TEST_FAIL,
+} adc_test_result_t;
+
+void HardFault_Handler(void);
+
+static void dac_init(void) {
+    RCC->AHB2ENR |= RCC_AHB2ENR_DAC1EN;
+    (void)RCC->AHB2ENR;
+
+    DAC1->CR &= ~(DAC_CR_EN1 | DAC_CR_TEN1);
+    DAC1->MCR &= ~DAC_MCR_MODE1_Msk;
+    DAC1->DHR12R1 = 0U;
+    DAC1->CR |= DAC_CR_EN1;
+}
+
+static void dac_write(uint16_t value) {
+    DAC1->DHR12R1 = value & DAC_DHR12R1_DACC1DHR_Msk;
+
+    for (volatile uint32_t i = 0U; i < ADC_TEST_DAC_SETTLE_CYCLES; i++) {
+        __NOP();
+    }
+}
+
+static uint16_t sample_error(uint16_t expected, uint16_t actual) {
+    return expected > actual ? expected - actual : actual - expected;
+}
+
+void PHAL_ADC_conversionCompleteCallback(PHAL_ADC_Handle_t *handle) {
+    if (handle != &adc_handle) {
+        return;
+    }
+
+    adc_test_conversion_error    = handle->transfer_error;
+    adc_test_conversion_complete = true;
+}
+
+static bool start_adc_dac_test(void) {
+    adc_test_expected = dac_test_codes[adc_test_index];
+    dac_write(adc_test_expected);
+
+    adc_test_conversion_complete = false;
+    adc_test_conversion_error    = false;
+    adc_test_wait_iterations     = 0U;
+
+    if (!PHAL_ADC_readDMA(&adc_handle, &adc_sample, 1U)) {
+        adc_test_failed_index = adc_test_index;
+        return false;
+    }
+
+    adc_test_conversion_started = true;
+    return true;
+}
+
+static adc_test_result_t run_adc_dac_test_step(void) {
+    if (!adc_test_conversion_started) {
+        return start_adc_dac_test() ? ADC_TEST_RUNNING : ADC_TEST_FAIL;
+    }
+
+    if (!adc_test_conversion_complete) {
+        adc_test_wait_iterations++;
+        if (adc_test_wait_iterations >= ADC_TEST_DMA_TIMEOUT) {
+            adc_test_failed_index = adc_test_index;
+            return ADC_TEST_FAIL;
+        }
+        return ADC_TEST_RUNNING;
+    }
+
+    adc_test_conversion_complete = false;
+    if (adc_test_conversion_error) {
+        adc_test_failed_index = adc_test_index;
+        return ADC_TEST_FAIL;
+    }
+
+    adc_test_actual = adc_sample;
+    adc_test_error  = sample_error(adc_test_expected, adc_test_actual);
+    if (adc_test_error > ADC_TEST_ALLOWED_ERROR) {
+        adc_test_failed_index = adc_test_index;
+        return ADC_TEST_FAIL;
+    }
+
+    adc_test_index++;
+    if (adc_test_index >= countof(dac_test_codes)) {
+        return ADC_TEST_PASS;
+    }
+
+    adc_test_expected      = dac_test_codes[adc_test_index];
+    adc_test_conversion_error = false;
+    adc_test_wait_iterations  = 0U;
+    dac_write(adc_test_expected);
+    return ADC_TEST_RUNNING;
+}
+
+int main(void) {
+    // 16 MHz system clock, no PLL
+    PHAL_RCC_init(PHAL_RCC_HSI_16MHZ);
+
+    if (!PHAL_initGPIO(gpio_config, countof(gpio_config))) {
+        HardFault_Handler();
+    }
+
+    dac_init();
+    if (!PHAL_ADC_init(&adc_handle, &adc_config)) {
+        HardFault_Handler();
+    }
+
+    adc_test_result_t result = ADC_TEST_RUNNING;
+    while (true) {
+        if (result == ADC_TEST_RUNNING) {
+            result = run_adc_dac_test_step();
+            if (result != ADC_TEST_RUNNING) {
+                adc_test_passed = result == ADC_TEST_PASS;
+                PHAL_writeGPIO(LED_GREEN_PORT, LED_GREEN_PIN, adc_test_passed);
+                PHAL_writeGPIO(LED_RED_PORT, LED_RED_PIN, !adc_test_passed);
+            }
+        }
+        __NOP();
+    }
+}
+
+void HardFault_Handler(void) {
+    while (1) {
+        __asm__("nop");
+    }
+}
+
+#endif // G4_TESTING_CHOSEN == TEST_ADC

--- a/source/g4_testing/g4_testing.h
+++ b/source/g4_testing/g4_testing.h
@@ -13,8 +13,9 @@
 #define TEST_CRC        8
 #define TEST_USB        9
 #define TEST_PWM        10
+#define TEST_ADC        11
 
 // Change this define to set the test compiled
-#define G4_TESTING_CHOSEN TEST_PWM
+#define G4_TESTING_CHOSEN TEST_BLINKY
 
 #endif // __G4_TESTING__


### PR DESCRIPTION
Refactored the STM32G4 ADC PHAL into public and private layers, added handle-based DMA reads, and updated existing ADC users to the new API. 

Added an ADC/DAC loopback test that connects PA4 to PA0 and compares ADC readings against five DAC output values. 